### PR TITLE
Upgrade BareBonesBrowserLauncher; improve linux support

### DIFF
--- a/client/src/com/mirth/connect/client/ui/BareBonesBrowserLaunch.java
+++ b/client/src/com/mirth/connect/client/ui/BareBonesBrowserLaunch.java
@@ -1,47 +1,73 @@
-// ///////////////////////////////////////////////////////
-// Bare Bones Browser Launch //
-// Version 1.5 //
-// December 10, 2005 //
-// Supports: Mac OS X, GNU/Linux, Unix, Windows XP //
-// Example Usage: //
-// String url = "http://www.centerkey.com/"; //
-// BareBonesBrowserLaunch.openURL(url); //
-// Public Domain Software -- Free to Use as You Like //
-// ///////////////////////////////////////////////////////
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025 Tony Germano <tony@germano.name>
+// SPDX-Contributor: Original Author Dem Pilafian (Original work licensed under WTFPL)
+
 package com.mirth.connect.client.ui;
 
-import java.lang.reflect.Method;
+import java.util.Arrays;
 
+/**
+ * Utility class to open a web page from a Swing application
+ * in the user's default browser.
+ * <p>
+ * Supports: Mac OS X, Linux, Unix, Windows
+ * <p>
+ * Example usage:<br>
+ * <code>&nbsp;&nbsp;
+ *    String url = "https://dna-engine.org/";<br>&nbsp;&nbsp;
+ *    BareBonesBrowserLaunch.openURL(url);</code>
+ * <p>
+ * Latest Version: <a href=https://centerkey.com/java/browser>
+ * https://centerkey.com/java/browser</a>
+ * <p>
+ * Published: October 24, 2010
+ * Modified: 2025
+ * <p>
+ *
+ * @author Dem Pilafian
+ * @version 3.2
+ */
 public class BareBonesBrowserLaunch {
 
+    static final String[] browsers = { "xdg-open", "x-www-browser", "google-chrome",
+            "firefox", "opera", "epiphany", "konqueror", "conkeror", "midori",
+            "kazehakase", "mozilla" };
+
+    /**
+     * Open the specified web page in the user's default browser
+     * 
+     * @param url A web address (URL) of a web page (example:
+     *            <code>"https://dna-engine.org/"</code>)
+     */
     public static void openURL(String url) {
-        String osName = System.getProperty("os.name");
-        try {
-            if (osName.startsWith("Mac OS")) {
-                Class<?> fileMgr = Class.forName("com.apple.eio.FileManager");
-                Method openURL = fileMgr.getDeclaredMethod("openURL", new Class[] { String.class });
-                openURL.invoke(null, new Object[] { url });
-            } else if (osName.startsWith("Windows")) {
-                Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + url);
-            } else {
-                // assume Unix or Linux
-                String[] browsers = { "firefox", "opera", "konqueror", "epiphany", "mozilla",
-                        "netscape" };
-                String browser = null;
-                for (int count = 0; count < browsers.length && browser == null; count++) {
-                    if (Runtime.getRuntime().exec(new String[] { "which",
-                            browsers[count] }).waitFor() == 0) {
-                        browser = browsers[count];
-                    }
+        try { // attempt to use Desktop library from JDK 1.6+
+            Class<?> d = Class.forName("java.awt.Desktop");
+            d.getDeclaredMethod("browse",
+                    new Class<?>[] { java.net.URI.class }).invoke(
+                            d.getDeclaredMethod("getDesktop").invoke(null),
+                            new Object[] { java.net.URI.create(url) });
+        } catch (Exception ignore) { // library not available or failed
+            String osName = System.getProperty("os.name");
+            try {
+                if (osName.startsWith("Mac OS")) {
+                    Class.forName("com.apple.eio.FileManager").getDeclaredMethod(
+                            "openURL", new Class<?>[] { String.class }).invoke(null,
+                                    new Object[] { url });
+                } else if (osName.startsWith("Windows"))
+                    Runtime.getRuntime().exec(new String[] {
+                            "rundll32", "url.dll,FileProtocolHandler", url });
+                else { // assume Unix or Linux
+                    String browser = null;
+                    for (String b : browsers)
+                        if (browser == null
+                                && Runtime.getRuntime().exec(new String[] { "which", b }).getInputStream().read() != -1)
+                            Runtime.getRuntime().exec(new String[] { browser = b, url });
+                    if (browser == null)
+                        throw new Exception(Arrays.toString(browsers));
                 }
-                if (browser == null) {
-                    throw new Exception("Could not find web browser");
-                } else {
-                    Runtime.getRuntime().exec(new String[] { browser, url });
-                }
+            } catch (Exception e) {
+                PlatformUI.MIRTH_FRAME.alertThrowable(PlatformUI.MIRTH_FRAME, e);
             }
-        } catch (Exception e) {
-            PlatformUI.MIRTH_FRAME.alertThrowable(PlatformUI.MIRTH_FRAME, e);
         }
     }
 }

--- a/manager/src/com/mirth/connect/manager/BareBonesBrowserLaunch.java
+++ b/manager/src/com/mirth/connect/manager/BareBonesBrowserLaunch.java
@@ -1,48 +1,73 @@
-// Bare Bones Browser Launch //
-// Version 1.5 //
-// December 10, 2005 //
-// Supports: Mac OS X, GNU/Linux, Unix, Windows XP //
-// Example Usage: //
-// String url = "http://www.centerkey.com/"; //
-// BareBonesBrowserLaunch.openURL(url); //
-// Public Domain Software -- Free to Use as You Like //
-/////////////////////////////////////////////////////////
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2025 Tony Germano <tony@germano.name>
+// SPDX-Contributor: Original Author Dem Pilafian (Original work licensed under WTFPL)
+
 package com.mirth.connect.manager;
 
-import java.lang.reflect.Method;
+import java.util.Arrays;
 
+/**
+ * Utility class to open a web page from a Swing application
+ * in the user's default browser.
+ * <p>
+ * Supports: Mac OS X, Linux, Unix, Windows
+ * <p>
+ * Example usage:<br>
+ * <code>&nbsp;&nbsp;
+ *    String url = "https://dna-engine.org/";<br>&nbsp;&nbsp;
+ *    BareBonesBrowserLaunch.openURL(url);</code>
+ * <p>
+ * Latest Version: <a href=https://centerkey.com/java/browser>
+ * https://centerkey.com/java/browser</a>
+ * <p>
+ * Published: October 24, 2010
+ * Modified: 2025
+ * <p>
+ *
+ * @author Dem Pilafian
+ * @version 3.2
+ */
 public class BareBonesBrowserLaunch {
 
-    private static final String errMsg = "Error attempting to launch web browser";
+    static final String[] browsers = { "xdg-open", "x-www-browser", "google-chrome",
+            "firefox", "opera", "epiphany", "konqueror", "conkeror", "midori",
+            "kazehakase", "mozilla" };
 
+    /**
+     * Open the specified web page in the user's default browser
+     * 
+     * @param url A web address (URL) of a web page (example:
+     *            <code>"https://dna-engine.org/"</code>)
+     */
     public static void openURL(String url) {
-        String osName = System.getProperty("os.name");
-        try {
-            if (osName.startsWith("Mac OS")) {
-                Class fileMgr = Class.forName("com.apple.eio.FileManager");
-                Method openURL = fileMgr.getDeclaredMethod("openURL", new Class[] { String.class });
-                openURL.invoke(null, new Object[] { url });
-            } else if (osName.startsWith("Windows")) {
-                Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + url);
-            } else {
-                // assume Unix or Linux
-                String[] browsers = { "firefox", "opera", "konqueror", "epiphany", "mozilla",
-                        "netscape" };
-                String browser = null;
-                for (int count = 0; count < browsers.length && browser == null; count++) {
-                    if (Runtime.getRuntime().exec(new String[] { "which",
-                            browsers[count] }).waitFor() == 0) {
-                        browser = browsers[count];
-                    }
+        try { // attempt to use Desktop library from JDK 1.6+
+            Class<?> d = Class.forName("java.awt.Desktop");
+            d.getDeclaredMethod("browse",
+                    new Class<?>[] { java.net.URI.class }).invoke(
+                            d.getDeclaredMethod("getDesktop").invoke(null),
+                            new Object[] { java.net.URI.create(url) });
+        } catch (Exception ignore) { // library not available or failed
+            String osName = System.getProperty("os.name");
+            try {
+                if (osName.startsWith("Mac OS")) {
+                    Class.forName("com.apple.eio.FileManager").getDeclaredMethod(
+                            "openURL", new Class<?>[] { String.class }).invoke(null,
+                                    new Object[] { url });
+                } else if (osName.startsWith("Windows"))
+                    Runtime.getRuntime().exec(new String[] {
+                            "rundll32", "url.dll,FileProtocolHandler", url });
+                else { // assume Unix or Linux
+                    String browser = null;
+                    for (String b : browsers)
+                        if (browser == null
+                                && Runtime.getRuntime().exec(new String[] { "which", b }).getInputStream().read() != -1)
+                            Runtime.getRuntime().exec(new String[] { browser = b, url });
+                    if (browser == null)
+                        throw new Exception(Arrays.toString(browsers));
                 }
-                if (browser == null) {
-                    throw new Exception("Could not find web browser");
-                } else {
-                    Runtime.getRuntime().exec(new String[] { browser, url });
-                }
+            } catch (Exception e) {
+                ManagerController.getInstance().alertErrorDialog("Could not open web browser.");
             }
-        } catch (Exception e) {
-            ManagerController.getInstance().alertErrorDialog("Could not open web browser.");
         }
     }
 }


### PR DESCRIPTION
Upgraded from 1.5 to latest version 3.2. Fixed deprecated error. Added xdg-open as first choice on linux systems.

fixes OpenIntegrationEngine/engine#65