### PR TITLE
simplify opening privacy policy link

### DIFF
--- a/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
+++ b/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
@@ -9,7 +9,6 @@
 
 package com.mirth.connect.client.ui;
 
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.event.WindowAdapter;
@@ -17,9 +16,7 @@ import java.awt.event.WindowEvent;
 import java.util.prefs.Preferences;
 
 import javax.swing.JDialog;
-import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkEvent.EventType;
-import javax.swing.event.HyperlinkListener;
 import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
@@ -177,19 +174,9 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
         
         contentTextPane.setParagraphAttributes(set, true);
         contentTextPane.setEditable(false);
-        contentTextPane.addHyperlinkListener(new HyperlinkListener() {
-            public void hyperlinkUpdate(HyperlinkEvent evt) {
-                if (evt.getEventType() == EventType.ACTIVATED && Desktop.isDesktopSupported()) {
-                    try {
-                        if (Desktop.isDesktopSupported()) {
-                            Desktop.getDesktop().browse(evt.getURL().toURI());
-                        } else {
-                            BareBonesBrowserLaunch.openURL(evt.getURL().toString());
-                        }
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
+        contentTextPane.addHyperlinkListener(event -> {
+            if (event.getEventType() == EventType.ACTIVATED) {
+                BareBonesBrowserLaunch.openURL(event.getURL().toString());
             }
         });
 


### PR DESCRIPTION
Fixes issue #86

Compiled using Oracle JDK 8. Link click worked on Windows 10.

I see several classes using `Desktop.isDesktopSupported()` which may warrant a code cleanup ticket.