### PR TITLE
replace MPL 2.0 licenses with vanilla text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-Copyright (c) NextGen Healthcare. All rights reserved.
-
-https://www.nextgen.com/products-and-services/integration-engine
-
-The software in this package is published under the terms of the MPL license a copy of which has been included below:
-
 Mozilla Public License Version 2.0
 ==================================
 
@@ -41,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/server/docs/LICENSE.txt
+++ b/server/docs/LICENSE.txt
@@ -1,9 +1,3 @@
-Copyright (c) NextGen Healthcare. All rights reserved.
-
-https://www.nextgen.com/products-and-services/integration-engine
-
-The software in this package is published under the terms of the MPL license a copy of which has been included below:
-
 Mozilla Public License Version 2.0
 ==================================
 
@@ -41,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"


### PR DESCRIPTION
A fresh copy of the license file was added by github.

This removes extra text from the top of the file which is not part of the license and does not apply to all MPL licensed code in the repository. Copyright information is retained in individual file headers.

A couple whitespace changes were also introduced by using a fresh copy of the license. Note that `LICENSE` in the root directory has unix line endings while `server/docs/LICENSE.txt` has windows line endings.