### PR TITLE
Allow disable telemetry from BrandingConstants

### DIFF
--- a/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
+++ b/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
@@ -9,6 +9,9 @@
 
 package com.mirth.connect.client.ui;
 
+import static com.mirth.connect.client.core.BrandingConstants.CENTRAL_USER_REGISTRATION;
+import static com.mirth.connect.client.core.BrandingConstants.MANDATORY_USER_REGISTRATION;
+
 import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Point;
@@ -47,10 +50,14 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
         finishButton.setEnabled(false);
 
         userEditPanel.setUser(this, currentUser);
-        userEditPanel.setRequiredFields(false, true);
-        if (currentUser.getId() == 1) {
-            registerCheckBox.setVisible(false);
-        }
+
+        final boolean isRegistrationMandatory = CENTRAL_USER_REGISTRATION && MANDATORY_USER_REGISTRATION && currentUser.getId() == 1;
+        registerCheckBox.setSelected(isRegistrationMandatory);
+        registerCheckBox.setEnabled(!isRegistrationMandatory);
+        registerCheckBox.setVisible(CENTRAL_USER_REGISTRATION);
+        registerCheckBoxActionPerformed(null);
+        userConsentCheckBox.setVisible(CENTRAL_USER_REGISTRATION);
+        contentTextPane.setVisible(CENTRAL_USER_REGISTRATION);
 
         jLabel2.setForeground(UIConstants.HEADER_TITLE_TEXT_COLOR);
         setModal(true);
@@ -151,7 +158,6 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
         jScrollPane1.setViewportView(jTextPane1);
         
         registerCheckBox.setBackground(new java.awt.Color(255, 255, 255));
-        registerCheckBox.setSelected(true);
         registerCheckBox.setText(String.format("Register user with %s", BrandingConstants.COMPANY_NAME));
         registerCheckBox.setToolTipText(String.format("<html>Register your user information with %s to help us<br>improve the product and provide better service.</html>", BrandingConstants.COMPANY_NAME));
         registerCheckBox.addActionListener(new java.awt.event.ActionListener() {
@@ -161,7 +167,6 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
         });
         
         userConsentCheckBox.setBackground(new java.awt.Color(255, 255, 255));
-        userConsentCheckBox.setSelected(true);
         userConsentCheckBox.setText(String.format("I consent to receive email updates and marketing messages from %s.", BrandingConstants.COMPANY_NAME));
         userConsentCheckBox.setToolTipText("<html></html>"); 
 
@@ -273,7 +278,7 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
                 return;
             }
 
-            if (registerCheckBox.isSelected()) {
+            if (registerCheckBox.isSelected() && CENTRAL_USER_REGISTRATION) {
                 parent.registerUser(user);
             }
 
@@ -316,7 +321,7 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
         	userConsentCheckBox.setSelected(false);
         	userConsentCheckBox.setEnabled(false);
         }
-        userEditPanel.setRequiredFields(false, true);
+        userEditPanel.setRequiredFields(allRequired, true);
     }//GEN-LAST:event_registerCheckBoxActionPerformed
     
     public boolean getResult() {

--- a/client/src/com/mirth/connect/client/ui/Frame.java
+++ b/client/src/com/mirth/connect/client/ui/Frame.java
@@ -9,6 +9,10 @@
 
 package com.mirth.connect.client.ui;
 
+import static com.mirth.connect.client.core.BrandingConstants.CENTRAL_USER_REGISTRATION;
+import static com.mirth.connect.client.core.BrandingConstants.CHECK_FOR_NOTIFICATIONS;
+import static com.mirth.connect.client.core.BrandingConstants.SEND_USAGE_STATISTICS;
+
 import java.awt.AWTEvent;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -1250,7 +1254,9 @@ public class Frame extends JXFrame {
         otherPane.setTitle("Other");
         otherPane.setName(TaskConstants.OTHER_KEY);
         otherPane.setFocusable(false);
-        addTask(TaskConstants.OTHER_NOTIFICATIONS, UIConstants.VIEW_NOTIFICATIONS, String.format("View notifications from %s.", BrandingConstants.PRODUCT_NAME), "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/flag_orange.png")), otherPane, null);
+        if (CHECK_FOR_NOTIFICATIONS) {
+            addTask(TaskConstants.OTHER_NOTIFICATIONS, UIConstants.VIEW_NOTIFICATIONS, String.format("View notifications from %s.", BrandingConstants.PRODUCT_NAME), "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/flag_orange.png")), otherPane, null);
+        }
         addTask(TaskConstants.OTHER_VIEW_USER_API, "View User API", String.format("View documentation for the %s User API.", BrandingConstants.PRODUCT_NAME), "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/page_white_text.png")), otherPane, null);
         addTask(TaskConstants.OTHER_VIEW_CLIENT_API, "View Client API", String.format("View documentation for the %s Client API.", BrandingConstants.PRODUCT_NAME), "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/page_white_text.png")), otherPane, null);
         addTask(TaskConstants.OTHER_HELP, "Help", String.format("View help for %s.", BrandingConstants.PRODUCT_NAME), "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/help.png")), otherPane, null);
@@ -1268,6 +1274,10 @@ public class Frame extends JXFrame {
     }
 
     public void updateNotificationTaskName(int notifications) {
+        if (!CHECK_FOR_NOTIFICATIONS) {
+            return;
+        }
+        
         String taskName = UIConstants.VIEW_NOTIFICATIONS;
         if (notifications > 0) {
             taskName += " (" + notifications + ")";
@@ -1949,6 +1959,10 @@ public class Frame extends JXFrame {
     }
 
     public void registerUser(final User user) {
+        if (!CENTRAL_USER_REGISTRATION) {
+            return;
+        }
+
         final String workingId = startWorking("Registering user...");
 
         SwingWorker<Void, Void> worker = new SwingWorker<Void, Void>() {
@@ -1972,6 +1986,10 @@ public class Frame extends JXFrame {
     }
 
     public void sendUsageStatistics() {
+        if (!SEND_USAGE_STATISTICS) {
+            return;
+        }
+
         UpdateSettings updateSettings = null;
         try {
             updateSettings = mirthClient.getUpdateSettings();

--- a/client/src/com/mirth/connect/client/ui/LoginPanel.java
+++ b/client/src/com/mirth/connect/client/ui/LoginPanel.java
@@ -9,6 +9,8 @@
 
 package com.mirth.connect.client.ui;
 
+import static com.mirth.connect.client.core.BrandingConstants.CHECK_FOR_NOTIFICATIONS;
+
 import java.awt.Color;
 import java.awt.Cursor;
 import java.util.Collections;
@@ -609,7 +611,8 @@ public class LoginPanel extends javax.swing.JFrame {
 
                     // Check for new notifications from update server if enabled
                     String checkForNotifications = userPreferences.getProperty("checkForNotifications");
-                    if (checkForNotifications == null || BooleanUtils.toBoolean(checkForNotifications)) {
+                    if (CHECK_FOR_NOTIFICATIONS 
+                        && (checkForNotifications == null || BooleanUtils.toBoolean(checkForNotifications))) {
                         Set<Integer> archivedNotifications = new HashSet<Integer>();
                         String archivedNotificationString = userPreferences.getProperty("archivedNotifications");
                         if (archivedNotificationString != null) {

--- a/client/src/com/mirth/connect/client/ui/SettingsPanelServer.java
+++ b/client/src/com/mirth/connect/client/ui/SettingsPanelServer.java
@@ -9,6 +9,8 @@
 
 package com.mirth.connect.client.ui;
 
+import static com.mirth.connect.client.core.BrandingConstants.SEND_USAGE_STATISTICS;
+
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Font;
@@ -81,8 +83,12 @@ public class SettingsPanelServer extends AbstractSettingsPanel {
         addTask(TaskConstants.SETTINGS_SERVER_RESTORE, "Restore Config", "Restore your server configuration from a server configuration XML file. This will remove and restore your channels, alerts, code templates, server properties, global scripts, and plugin properties.", "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/report_go.png")));
         addTask(TaskConstants.SETTINGS_CLEAR_ALL_STATS, "Clear All Statistics", "Reset the current and lifetime statistics for all channels.", "", new ImageIcon(com.mirth.connect.client.ui.Frame.class.getResource("images/chart_bar_delete.png")));
 
-        provideUsageStatsMoreInfoLabel.setToolTipText(BrandingConstants.PRIVACY_TOOLTIP);
-        provideUsageStatsMoreInfoLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        if (!SEND_USAGE_STATISTICS) {
+            provideUsageStatsLabel.setVisible(false);
+            provideUsageStatsYesRadio.setVisible(false);
+            provideUsageStatsNoRadio.setVisible((false));
+            provideUsageStatsMoreInfoLabel.setVisible(false);
+        }
         queueBufferSizeField.setDocument(new MirthFieldConstraints(8, false, false, true));
         smtpTimeoutField.setDocument(new MirthFieldConstraints(0, false, false, false));
         administratorAutoLogoutIntervalField.setDocument(new MirthFieldConstraints(2, false, false, true));
@@ -728,8 +734,8 @@ public class SettingsPanelServer extends AbstractSettingsPanel {
         provideUsageStatsButtonGroup.add(provideUsageStatsNoRadio);
 
         provideUsageStatsMoreInfoLabel = new JLabel("<html><font color=blue><u>More Info</u></font></html>");
-        provideUsageStatsMoreInfoLabel.setEnabled(false);
-        provideUsageStatsMoreInfoLabel.setVisible(false);
+        provideUsageStatsMoreInfoLabel.setToolTipText(BrandingConstants.PRIVACY_TOOLTIP);
+        provideUsageStatsMoreInfoLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
         provideUsageStatsMoreInfoLabel.addMouseListener(new MouseAdapter() {
             public void mouseClicked(MouseEvent evt) {
                 provideUsageStatsMoreInfoLabelMouseClicked(evt);

--- a/server/src/com/mirth/connect/client/core/BrandingConstants.java
+++ b/server/src/com/mirth/connect/client/core/BrandingConstants.java
@@ -9,4 +9,12 @@ public class BrandingConstants {
     public static final String CLIENT_CONNECTION_HEADER = "openintegrationengine-client";
 
     public static final String SERVER_CERTIFICATE_CN = "oie-engine";
+
+    public static final String CONNECT_SERVER_URL = "https://connect.openintegrationengine.org";
+    public static final String NOTIFICATIONS_URL = "https://api.github.com/repos/openintegrationengine/engine/releases";
+
+    public static final boolean CENTRAL_USER_REGISTRATION = false;
+    public static final boolean MANDATORY_USER_REGISTRATION = false;
+    public static final boolean CHECK_FOR_NOTIFICATIONS = true;
+    public static final boolean SEND_USAGE_STATISTICS = false;
 }

--- a/server/src/com/mirth/connect/client/core/ConnectServiceUtil.java
+++ b/server/src/com/mirth/connect/client/core/ConnectServiceUtil.java
@@ -51,21 +51,27 @@ import org.apache.http.util.EntityUtils;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.github.zafarkhaja.semver.Version;
+
 import com.mirth.connect.model.User;
 import com.mirth.connect.model.converters.ObjectXMLSerializer;
 import com.mirth.connect.model.notification.Notification;
 import com.mirth.connect.util.MirthSSLUtil;
 
 public class ConnectServiceUtil {
-    private final static String URL_CONNECT_SERVER = "https://connect.mirthcorp.com";
+    private final static String URL_CONNECT_SERVER = BrandingConstants.CONNECT_SERVER_URL;
     private final static String URL_REGISTRATION_SERVLET = "/RegistrationServlet";
     private final static String URL_USAGE_SERVLET = "/UsageStatisticsServlet";
-    private static String URL_NOTIFICATIONS = "https://api.github.com/repos/openintegrationengine/engine/releases";
+    private static String URL_NOTIFICATIONS = BrandingConstants.NOTIFICATIONS_URL;
     private final static int TIMEOUT = 10000;
     public final static Integer MILLIS_PER_DAY = 86400000;
 
     public static void registerUser(String serverId, String mirthVersion, User user, String[] protocols, String[] cipherSuites) throws ClientException {
+        if (!BrandingConstants.CENTRAL_USER_REGISTRATION) {
+            throw new UnsupportedOperationException("User Registration is disabled");
+        }
+
         CloseableHttpClient httpClient = null;
         CloseableHttpResponse httpResponse = null;
         NameValuePair[] params = { new BasicNameValuePair("serverId", serverId),
@@ -107,6 +113,10 @@ public class ConnectServiceUtil {
      * @throws Exception should anything fail dealing with the web request and the handling of its response
      */
     public static List<Notification> getNotifications(String serverId, String mirthVersion, Map<String, String> extensionVersions, String[] protocols, String[] cipherSuites) throws Exception {
+        if (!BrandingConstants.CHECK_FOR_NOTIFICATIONS) {
+            throw new UnsupportedOperationException("Checking for Notifications is disabled.");
+        }
+        
         List<Notification> validNotifications = Collections.emptyList();
         Optional<Version> parsedMirthVersion = Version.tryParse(mirthVersion);
         if (!parsedMirthVersion.isPresent()) {
@@ -208,6 +218,10 @@ public class ConnectServiceUtil {
     }
 
     public static int getNotificationCount(String serverId, String mirthVersion, Map<String, String> extensionVersions, Set<Integer> archivedNotifications, String[] protocols, String[] cipherSuites) {
+        if (!BrandingConstants.CHECK_FOR_NOTIFICATIONS) {
+            throw new UnsupportedOperationException("Checking for Notifications is disabled.");
+        }
+
         Long notificationCount = 0L;
         try {
             notificationCount = getNotifications(serverId, mirthVersion, extensionVersions, protocols, cipherSuites)
@@ -222,6 +236,10 @@ public class ConnectServiceUtil {
     }
 
     public static boolean sendStatistics(String serverId, String mirthVersion, boolean server, String data, String[] protocols, String[] cipherSuites) {
+        if (!BrandingConstants.SEND_USAGE_STATISTICS) {
+            throw new UnsupportedOperationException("Sending Usage Statistics is disabled.");
+        }
+        
         if (data == null) {
             return false;
         }

--- a/server/src/com/mirth/connect/server/Mirth.java
+++ b/server/src/com/mirth/connect/server/Mirth.java
@@ -401,8 +401,10 @@ public class Mirth extends Thread {
         printSplashScreen();
 
         // schedule usage statistics to be sent at startup and every 24 hours
-        Timer timer = new Timer();
-        timer.schedule(new UsageSenderTask(), 0, ConnectServiceUtil.MILLIS_PER_DAY);
+        if (BrandingConstants.SEND_USAGE_STATISTICS) {
+            Timer timer = new Timer();
+            timer.schedule(new UsageSenderTask(), 0, ConnectServiceUtil.MILLIS_PER_DAY);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #5 by adding branding constants:

- CONNECT_SERVER_URL
- CENTRAL_USER_REGISTRATION
- CHECK_FOR_NOTIFICATIONS
- SEND_USAGE_STATISTICS

As is, stats and registrations are sent to the non-existent https://connect.openintegrationengine.org/.  Not sure what is desired, but I presume it is easier to keep it enabled than to try to merge a re-enable later.

This also updates the HttpClient configuration for notifications and telemetry to use the system defaults.  I presume the preceding was an over-zealous edit during the "no PHI over anything but TLS1.2" heyday.

Related: #114
Alternative: #107 