### PR TITLE
Fix usernames being case sensitive

### DIFF
--- a/server/dbconf/derby/derby-user.xml
+++ b/server/dbconf/derby/derby-user.xml
@@ -33,7 +33,7 @@
 		FROM PERSON
 		<where>
          	<if test='id != null'>ID = #{id}</if>
-         	<if test='username != null'>AND USERNAME = #{username}</if>
+         	<if test='username != null'>AND LOWER(USERNAME) = LOWER(#{username})</if>
       	</where>
 	</select>
 

--- a/server/dbconf/oracle/oracle-user.xml
+++ b/server/dbconf/oracle/oracle-user.xml
@@ -33,7 +33,7 @@
 		FROM PERSON
 		<where>
 			<if test="id != null">ID = #{id}</if>
-			<if test="username != null">AND USERNAME = #{username}</if>
+			<if test="username != null">AND USERNAME COLLATE BINARY_CI = #{username}</if>
 		</where>
 	</select>
 

--- a/server/dbconf/postgres/postgres-user.xml
+++ b/server/dbconf/postgres/postgres-user.xml
@@ -29,7 +29,7 @@
 		FROM PERSON
 		<where>
          <if test='id != null'>AND ID = #{id}</if>
-         <if test='username != null'>AND USERNAME = #{username}</if>
+         <if test='username != null'>AND LOWER(USERNAME) = LOWER(#{username})</if>
       </where>
 	  </select>
    <select id='getUserCredentials'

--- a/server/src/com/mirth/connect/server/controllers/DefaultUserController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultUserController.java
@@ -333,7 +333,7 @@ public class DefaultUserController extends UserController {
                     if (loginRequirementsChecker.isPasswordExpired(passwordTime, currentTime)) {
                         // Let 0 be infinite grace period, -1 be no grace period
                         if (passwordRequirements.getGracePeriod() == 0) {
-                            loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS_GRACE_PERIOD, "Your password has expired. Please change your password now.");
+                            loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS_GRACE_PERIOD, "Your password has expired. Please change your password now.", validUser.getUsername());
                         } else if (passwordRequirements.getGracePeriod() > 0) {
                             // If there has never been a grace time, start it now
                             long gracePeriodStartTime;
@@ -351,7 +351,7 @@ public class DefaultUserController extends UserController {
 
                             long graceTimeRemaining = loginRequirementsChecker.getGraceTimeRemaining(gracePeriodStartTime, currentTime);
                             if (graceTimeRemaining > 0) {
-                                loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS_GRACE_PERIOD, "Your password has expired. You are required to change your password in the next " + loginRequirementsChecker.getPrintableGraceTimeRemaining(graceTimeRemaining) + ".");
+                                loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS_GRACE_PERIOD, "Your password has expired. You are required to change your password in the next " + loginRequirementsChecker.getPrintableGraceTimeRemaining(graceTimeRemaining) + ".", validUser.getUsername());
                             }
                         }
 
@@ -374,7 +374,7 @@ public class DefaultUserController extends UserController {
 
                 // If nothing failed (loginStatus != null), set SUCCESS now
                 if (loginStatus == null) {
-                    loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS, "");
+                    loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS, "", validUser.getUsername());
 
                     // Clear the user's grace period if one exists
                     if (validUser.getGracePeriodStart() != null) {


### PR DESCRIPTION
Closes #122 / original [#5569](https://github.com/nextgenhealthcare/connect/issues/5569) by:

- Normalizing username after login success
- Using case-insensitive comparisons in DB

Implementation Notes:
- Used `LOWER()` in pgsql instead of collation to avoid having to rely upon system defaults or database defined collation.  Presumably table is not so large that sargability is a concern (since we're loading the full table to the client on each login)
- No collation support seems to exist in Derby, so `LOWER()`
- MSSQL and MySQL already case insensitive by system default