### PR TITLE
Avoid crash when invalid URI is passed to test file write

### DIFF
--- a/server/src/com/mirth/connect/connectors/file/FileConnectorServlet.java
+++ b/server/src/com/mirth/connect/connectors/file/FileConnectorServlet.java
@@ -65,7 +65,12 @@ public class FileConnectorServlet extends MirthServlet implements FileConnectorS
             int timeout = Integer.parseInt(timeoutString);
 
             FileConnector fileConnector = new FileConnector(channelId, connectorProperties, null);
-            URI address = fileConnector.getEndpointURI(host, scheme, schemeProperties, secure);
+            URI address;
+            try {
+                address = fileConnector.getEndpointURI(host, scheme, schemeProperties, secure);
+            } catch (Exception e) {
+                return new ConnectionTestResponse(ConnectionTestResponse.Type.FAILURE, "Unable to parse URL, Reason: " + e.getMessage());
+            }
             String addressHost = address.getHost();
             int port = address.getPort();
             String dir = address.getPath();


### PR DESCRIPTION
Closes #124 / original [#4963](https://github.com/nextgenhealthcare/connect/issues/4963).

Updates server to provide a normal failure when a URI can't be parsed.

Implementation notes:
- I did not add separate client-side verification since it's unclear to me how to validate in a manner that supports all of the various file write options.  The new error when no directory is specified is 
![new error](https://github.com/user-attachments/assets/07194896-1823-42d1-96e2-914cb3c3ae89)
