### PR TITLE
Default 24 hour notation for search criteria

### DIFF
--- a/client/src/com/mirth/connect/client/ui/browsers/event/EventBrowser.form
+++ b/client/src/com/mirth/connect/client/ui/browsers/event/EventBrowser.form
@@ -55,6 +55,7 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" attributes="0">
                       <Component id="allDayCheckBox" min="-2" max="-2" attributes="0"/>
+                      <Component id="hourNotation24" min="-2" max="-2" attributes="0"/>
                       <EmptySpace min="-2" pref="19" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" max="-2" attributes="0">
                           <Component id="levelBoxInformation" alignment="0" pref="95" max="32767" attributes="0"/>
@@ -163,7 +164,10 @@
                           <Component id="allDayCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="levelBoxWarning" min="-2" pref="16" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="levelBoxWarning" min="-2" pref="16" max="-2" attributes="0"/>
+                          <Component id="hourNotation24" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="levelBoxError" pref="16" max="-2" attributes="0"/>
                   </Group>
@@ -285,6 +289,20 @@
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="allDayCheckBoxActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="com.mirth.connect.client.ui.components.MirthCheckBox" name="hourNotation24">
+      <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+          <Color blue="ff" green="ff" red="ff" type="rgb"/>
+        </Property>
+        <Property name="text" type="java.lang.String" value="24 hour"/>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+          <Font name="Lucida Grande" size="11" style="0"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="hourNotation24ItemStateChanged"/>
       </Events>
     </Component>
     <Container class="javax.swing.JScrollPane" name="lastSearchCriteriaPane">

--- a/client/src/com/mirth/connect/client/ui/browsers/event/EventBrowser.java
+++ b/client/src/com/mirth/connect/client/ui/browsers/event/EventBrowser.java
@@ -94,6 +94,7 @@ public class EventBrowser extends javax.swing.JPanel {
     private EventBrowserAdvancedFilter advancedSearchPopup;
     private Map<Integer, String> userMapById = new LinkedHashMap<Integer, String>();
     private SwingWorker<Void, Void> worker;
+    private boolean use24hourNotation = true;
 
     /**
      * Constructs the new event browser and sets up its default information/layout.
@@ -138,6 +139,7 @@ public class EventBrowser extends javax.swing.JPanel {
             public void propertyChange(PropertyChangeEvent arg0) {
                 allDayCheckBox.setEnabled(startDatePicker.getDate() != null || endDatePicker.getDate() != null);
                 startTimePicker.setEnabled(startDatePicker.getDate() != null && !allDayCheckBox.isSelected());
+                hourNotation24.setEnabled(startDatePicker.getDate() != null || endDatePicker.getDate() != null);
             }
         });
 
@@ -146,6 +148,7 @@ public class EventBrowser extends javax.swing.JPanel {
             public void propertyChange(PropertyChangeEvent arg0) {
                 allDayCheckBox.setEnabled(startDatePicker.getDate() != null || endDatePicker.getDate() != null);
                 endTimePicker.setEnabled(endDatePicker.getDate() != null && !allDayCheckBox.isSelected());
+                hourNotation24.setEnabled(startDatePicker.getDate() != null || endDatePicker.getDate() != null);
             }
         });
 
@@ -207,7 +210,7 @@ public class EventBrowser extends javax.swing.JPanel {
     }
 
     private Calendar getCalendar(MirthDatePicker datePicker, MirthTimePicker timePicker) throws ParseException {
-        DateFormatter timeFormatter = new DateFormatter(new SimpleDateFormat("hh:mm aa"));
+        DateFormatter timeFormatter = new DateFormatter(new SimpleDateFormat(use24hourNotation ? "HH:mm" : "hh:mm aa"));
         Date date = datePicker.getDate();
         String time = timePicker.getDate();
 
@@ -582,6 +585,7 @@ public class EventBrowser extends javax.swing.JPanel {
         endDatePicker.setDate(null);
         nameField.setText("");
         allDayCheckBox.setSelected(false);
+        hourNotation24.setSelected(true);
         levelBoxInformation.setSelected(false);
         levelBoxWarning.setSelected(false);
         levelBoxError.setSelected(false);
@@ -892,6 +896,7 @@ public class EventBrowser extends javax.swing.JPanel {
         eventAttributesTable = null;
         resetButton = new javax.swing.JButton();
         allDayCheckBox = new com.mirth.connect.client.ui.components.MirthCheckBox();
+        hourNotation24 = new com.mirth.connect.client.ui.components.MirthCheckBox();
         lastSearchCriteriaPane = new javax.swing.JScrollPane();
         lastSearchCriteria = new javax.swing.JTextArea();
         nextPageButton = new javax.swing.JButton();
@@ -909,8 +914,8 @@ public class EventBrowser extends javax.swing.JPanel {
         endDatePicker = new com.mirth.connect.client.ui.components.MirthDatePicker();
         startDatePicker = new com.mirth.connect.client.ui.components.MirthDatePicker();
         nameField = new javax.swing.JTextField();
-        startTimePicker = new com.mirth.connect.client.ui.components.MirthTimePicker();
-        endTimePicker = new com.mirth.connect.client.ui.components.MirthTimePicker();
+        startTimePicker = new com.mirth.connect.client.ui.components.MirthTimePicker((use24hourNotation ? "HH:mm" : "hh:mm aa"), Calendar.MINUTE);
+        endTimePicker = new com.mirth.connect.client.ui.components.MirthTimePicker((use24hourNotation ? "HH:mm" : "hh:mm aa"), Calendar.MINUTE);
         filterButton = new javax.swing.JButton();
         advSearchButton = new javax.swing.JButton();
         levelBoxInformation = new com.mirth.connect.client.ui.components.MirthCheckBox();
@@ -966,6 +971,17 @@ public class EventBrowser extends javax.swing.JPanel {
         allDayCheckBox.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 allDayCheckBoxActionPerformed(evt);
+            }
+        });
+
+        hourNotation24.setSelected(use24hourNotation);
+        hourNotation24.setBackground(new java.awt.Color(255, 255, 255));
+        hourNotation24.setText("24 hour");
+        hourNotation24.setToolTipText("Use 24 hour notation");
+        hourNotation24.setFont(new java.awt.Font("Lucida Grande", 0, 11)); // NOI18N
+        hourNotation24.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                hourNotation24ItemStateChanged(evt);
             }
         });
 
@@ -1108,7 +1124,9 @@ public class EventBrowser extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
-                        .addComponent(allDayCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                            .addComponent(allDayCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(hourNotation24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(19, 19, 19)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                             .addComponent(levelBoxInformation, javax.swing.GroupLayout.DEFAULT_SIZE, 95, Short.MAX_VALUE)
@@ -1192,7 +1210,9 @@ public class EventBrowser extends javax.swing.JPanel {
                             .addComponent(levelBoxInformation, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(allDayCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(levelBoxWarning, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(levelBoxWarning, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(hourNotation24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(levelBoxError, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(layout.createSequentialGroup()
@@ -1211,6 +1231,12 @@ public class EventBrowser extends javax.swing.JPanel {
         startTimePicker.setEnabled(startDatePicker.getDate() != null && !allDayCheckBox.isSelected());
         endTimePicker.setEnabled(endDatePicker.getDate() != null && !allDayCheckBox.isSelected());
     }//GEN-LAST:event_allDayCheckBoxActionPerformed
+
+    private void hourNotation24ItemStateChanged(java.awt.event.ItemEvent evt) {
+        use24hourNotation = hourNotation24.isSelected();
+        startTimePicker.setFormatter(use24hourNotation ? "HH:mm" : "hh:mm aa");
+        endTimePicker.setFormatter(use24hourNotation ? "HH:mm" : "hh:mm aa");
+    }//GEN-LAST:event_hourNotation24ItemStateChanged
 
     private void nextPageButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_nextPageButtonActionPerformed
         loadPageNumber(events.getPageNumber() + 1);
@@ -1289,6 +1315,7 @@ public class EventBrowser extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton advSearchButton;
     private com.mirth.connect.client.ui.components.MirthCheckBox allDayCheckBox;
+    private com.mirth.connect.client.ui.components.MirthCheckBox hourNotation24;
     private com.mirth.connect.client.ui.components.MirthButton countButton;
     private com.mirth.connect.client.ui.components.MirthDatePicker endDatePicker;
     private com.mirth.connect.client.ui.components.MirthTimePicker endTimePicker;

--- a/client/src/com/mirth/connect/client/ui/browsers/message/MessageBrowser.form
+++ b/client/src/com/mirth/connect/client/ui/browsers/message/MessageBrowser.form
@@ -838,6 +838,7 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="allDayCheckBox" min="-2" max="-2" attributes="0"/>
+                      <Component id="hourNotation24" min="-2" max="-2" attributes="0"/>
                       <Component id="filterButton" alignment="0" min="-2" pref="63" max="-2" attributes="0"/>
                       <Component id="regexTextSearchCheckBox" min="-2" max="-2" attributes="0"/>
                   </Group>
@@ -954,7 +955,10 @@
                                       <Component id="allDayCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                                   </Group>
                                   <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="statusBoxTransformed" min="-2" pref="16" max="-2" attributes="0"/>
+                                  <Group type="103" groupAlignment="3" attributes="0">
+                                      <Component id="statusBoxTransformed" min="-2" pref="16" max="-2" attributes="0"/>
+                                      <Component id="hourNotation24" alignment="3" min="-2" max="-2" attributes="0"/>
+                                  </Group>
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Component id="statusBoxFiltered" pref="16" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
@@ -1235,6 +1239,20 @@
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="allDayCheckBoxActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="com.mirth.connect.client.ui.components.MirthCheckBox" name="hourNotation24">
+          <Properties>
+            <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+              <Color blue="ff" green="ff" red="ff" type="rgb"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="24 hour"/>
+            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+              <Font name="Lucida Grande" size="11" style="0"/>
+            </Property>
+          </Properties>
+          <Events>
+            <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="hourNotation24ItemStateChanged"/>
           </Events>
         </Component>
         <Component class="com.mirth.connect.client.ui.components.MirthDatePicker" name="mirthDatePicker2">

--- a/client/src/com/mirth/connect/client/ui/browsers/message/MessageBrowser.java
+++ b/client/src/com/mirth/connect/client/ui/browsers/message/MessageBrowser.java
@@ -172,6 +172,8 @@ public class MessageBrowser extends javax.swing.JPanel {
 
     private List<Integer> selectedMetaDataIds;
 
+    private boolean use24hourNotation = true;
+
     /**
      * Constructs the new message browser and sets up its default information/layout
      */
@@ -250,6 +252,7 @@ public class MessageBrowser extends javax.swing.JPanel {
             public void propertyChange(PropertyChangeEvent arg0) {
                 allDayCheckBox.setEnabled(mirthDatePicker1.getDate() != null || mirthDatePicker2.getDate() != null);
                 mirthTimePicker1.setEnabled(mirthDatePicker1.getDate() != null && !allDayCheckBox.isSelected());
+                hourNotation24.setEnabled(mirthDatePicker1.getDate() != null || mirthDatePicker2.getDate() != null);
             }
         });
 
@@ -258,6 +261,7 @@ public class MessageBrowser extends javax.swing.JPanel {
             public void propertyChange(PropertyChangeEvent arg0) {
                 allDayCheckBox.setEnabled(mirthDatePicker1.getDate() != null || mirthDatePicker2.getDate() != null);
                 mirthTimePicker2.setEnabled(mirthDatePicker2.getDate() != null && !allDayCheckBox.isSelected());
+                hourNotation24.setEnabled(mirthDatePicker1.getDate() != null || mirthDatePicker2.getDate() != null);
             }
         });
 
@@ -423,6 +427,7 @@ public class MessageBrowser extends javax.swing.JPanel {
         textSearchField.setText("");
         regexTextSearchCheckBox.setSelected(false);
         allDayCheckBox.setSelected(false);
+        hourNotation24.setSelected(true);
         statusBoxReceived.setSelected(false);
         statusBoxTransformed.setSelected(false);
         statusBoxFiltered.setSelected(false);
@@ -499,7 +504,7 @@ public class MessageBrowser extends javax.swing.JPanel {
     }
 
     private Calendar getCalendar(MirthDatePicker datePicker, MirthTimePicker timePicker) throws ParseException {
-        DateFormatter timeFormatter = new DateFormatter(new SimpleDateFormat("hh:mm aa"));
+        DateFormatter timeFormatter = new DateFormatter(new SimpleDateFormat(use24hourNotation ? "HH:mm" : "hh:mm aa"));
         Date date = datePicker.getDate();
         String time = timePicker.getDate();
 
@@ -2381,11 +2386,12 @@ public class MessageBrowser extends javax.swing.JPanel {
         advSearchButton = new javax.swing.JButton();
         pageSizeField = new com.mirth.connect.client.ui.components.MirthTextField();
         statusBoxError = new com.mirth.connect.client.ui.components.MirthCheckBox();
-        mirthTimePicker2 = new com.mirth.connect.client.ui.components.MirthTimePicker();
+        mirthTimePicker2 = new com.mirth.connect.client.ui.components.MirthTimePicker((use24hourNotation ? "HH:mm" : "hh:mm aa"), Calendar.MINUTE);
         statusBoxReceived = new com.mirth.connect.client.ui.components.MirthCheckBox();
         pageGoButton = new javax.swing.JButton();
         statusBoxTransformed = new com.mirth.connect.client.ui.components.MirthCheckBox();
-        mirthTimePicker1 = new com.mirth.connect.client.ui.components.MirthTimePicker();
+        mirthTimePicker1 = new com.mirth.connect.client.ui.components.MirthTimePicker((use24hourNotation ? "HH:mm" : "hh:mm aa"), Calendar.MINUTE);
+        hourNotation24 = new com.mirth.connect.client.ui.components.MirthCheckBox();
         jLabel3 = new javax.swing.JLabel();
         allDayCheckBox = new com.mirth.connect.client.ui.components.MirthCheckBox();
         mirthDatePicker2 = new com.mirth.connect.client.ui.components.MirthDatePicker();
@@ -2917,6 +2923,16 @@ public class MessageBrowser extends javax.swing.JPanel {
         regexTextSearchCheckBox.setText("Regex");
         regexTextSearchCheckBox.setToolTipText("<html> Search all message content for a match to the regular expression pattern.<br/> Regex matching could be a very costly operation and should be used with<br/> caution, specially with large amount of messages. Any message content<br/> that was encrypted by this channel will not be searchable. Only supported<br/> on PostgreSQL, Oracle and MySQL databases.</html> ");
 
+        hourNotation24.setBackground(new java.awt.Color(255, 255, 255));
+        hourNotation24.setText("24 hour");
+        hourNotation24.setToolTipText("Use 24 hour notation");
+        hourNotation24.setFont(new java.awt.Font("Lucida Grande", 0, 11)); // NOI18N
+        hourNotation24.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                hourNotation24ItemStateChanged(evt);
+            }
+        });
+
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -2949,6 +2965,7 @@ public class MessageBrowser extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(allDayCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(hourNotation24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(filterButton, javax.swing.GroupLayout.PREFERRED_SIZE, 63, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(regexTextSearchCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
@@ -3044,7 +3061,9 @@ public class MessageBrowser extends javax.swing.JPanel {
                                     .addComponent(statusBoxReceived, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
                                     .addComponent(allDayCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(statusBoxTransformed, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                                    .addComponent(statusBoxTransformed, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addComponent(hourNotation24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(statusBoxFiltered, javax.swing.GroupLayout.PREFERRED_SIZE, 16, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -3191,6 +3210,12 @@ public class MessageBrowser extends javax.swing.JPanel {
         mirthTimePicker2.setEnabled(mirthDatePicker2.getDate() != null && !allDayCheckBox.isSelected());
     }//GEN-LAST:event_allDayCheckBoxActionPerformed
 
+    private void hourNotation24ItemStateChanged(java.awt.event.ItemEvent evt) {
+        use24hourNotation = hourNotation24.isSelected();
+        mirthTimePicker1.setFormatter(use24hourNotation ? "HH:mm" : "hh:mm aa");
+        mirthTimePicker2.setFormatter(use24hourNotation ? "HH:mm" : "hh:mm aa");
+    }//GEN-LAST:event_hourNotation24ItemStateChanged
+
     private void pageGoButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_pageGoButtonActionPerformed
         jumpToPageNumber();
     }//GEN-LAST:event_pageGoButtonActionPerformed
@@ -3269,6 +3294,7 @@ public class MessageBrowser extends javax.swing.JPanel {
     private javax.swing.JScrollPane messageScrollPane;
     protected com.mirth.connect.client.ui.components.MirthTreeTable messageTreeTable;
     private javax.swing.ButtonGroup messagesGroup;
+    private com.mirth.connect.client.ui.components.MirthCheckBox hourNotation24;
     private com.mirth.connect.client.ui.components.MirthDatePicker mirthDatePicker1;
     private com.mirth.connect.client.ui.components.MirthDatePicker mirthDatePicker2;
     private com.mirth.connect.client.ui.components.MirthTimePicker mirthTimePicker1;

--- a/client/src/com/mirth/connect/client/ui/components/MirthTimePicker.java
+++ b/client/src/com/mirth/connect/client/ui/components/MirthTimePicker.java
@@ -49,7 +49,6 @@ public class MirthTimePicker extends JSpinner {
     public void init(String format, int accuracy) {
         this.parent = PlatformUI.MIRTH_FRAME;
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat(format);
         GregorianCalendar calendar = new GregorianCalendar();
         Date now = calendar.getTime();
         SpinnerDateModel dateModel = new SpinnerDateModel(now, null, null, accuracy);
@@ -70,9 +69,7 @@ public class MirthTimePicker extends JSpinner {
             public void keyReleased(KeyEvent e) {}
         });
 
-        DefaultFormatterFactory factory = (DefaultFormatterFactory) tf.getFormatterFactory();
-        formatter = (DateFormatter) factory.getDefaultFormatter();
-        formatter.setFormat(dateFormat);
+        setFormatter(format);
         fireStateChanged();
 
         this.addChangeListener(new ChangeListener() {
@@ -83,6 +80,15 @@ public class MirthTimePicker extends JSpinner {
                 }
             }
         });
+    }
+
+    public void setFormatter(String formatString) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(formatString);
+        JFormattedTextField tf = ((JSpinner.DefaultEditor) getEditor()).getTextField();
+        DefaultFormatterFactory factory = (DefaultFormatterFactory) tf.getFormatterFactory();
+        formatter = (DateFormatter) factory.getDefaultFormatter();
+        formatter.setFormat(dateFormat);
+        fireStateChanged();
     }
 
     public void setSaveEnabled(boolean saveEnabled) {


### PR DESCRIPTION
Adds a checkbox to the Messages Browser and Events Browser which toggles the time format of the time input fields between `HH:mm` and `hh:mm aa`. On form load and on search reset, it defaults to 24hr notation.

I used most of the previous PR, but I changed the listener to one that responds to `JCheckbox.setSelected(bool)`. Changes to the `.form` files were also included, but those may be completely unused.

**Related**
Previous PR - https://github.com/nextgenhealthcare/connect/pull/5989
Summary table in https://github.com/OpenIntegrationEngine/engine/issues/121