### PR TITLE
Remove empty extensionmanager-client.jar

### DIFF
--- a/client/ant-build.xml
+++ b/client/ant-build.xml
@@ -46,7 +46,6 @@
 		<property name="plugins.dashboardstatus" value="${extensions}/dashboardstatus" />
 		<property name="plugins.destinationsetfilter" value="${extensions}/destinationsetfilter" />
 		<property name="plugins.dicomviewer" value="${extensions}/dicomviewer" />
-		<property name="plugins.extensionmanager" value="${extensions}/extensionmanager" />
 		<property name="plugins.httpauth" value="${extensions}/httpauth" />
 		<property name="plugins.imageviewer" value="${extensions}/imageviewer" />
 		<property name="plugins.javascriptrule" value="${extensions}/javascriptrule" />
@@ -234,11 +233,6 @@
 			<include name="com/mirth/connect/plugins/dicomviewer/**" />
 		</jar>
 
-		<mkdir dir="${plugins.extensionmanager}" />
-		<jar destfile="${plugins.extensionmanager}/extensionmanager-client.jar" basedir="${classes}">
-			<include name="com/mirth/connect/plugins/extensionmanager/**" />
-		</jar>
-		
 		<mkdir dir="${plugins.globalmapviewer}" />
 		<jar destfile="${plugins.globalmapviewer}/globalmapviewer-client.jar" basedir="${classes}">
 			<include name="com/mirth/connect/plugins/globalmapviewer/**" />


### PR DESCRIPTION
ExtensionManager apparently used to be a plugin, but it has not been for some time. The step in the client build script that produced the extension jar was not removed at the same time and has been producing an effectively empty jar file with no classes and only a manifest. The actual extensionmanager related classes are included in mirth-client.jar.

Related: 027ae2405ee6fe66b26b29a28e5315fcaf1dace0