### PR TITLE
Java 8u261 added support for TLS1.3, avoid assuming otherwise

### DIFF
--- a/server/test/com/mirth/connect/util/MirthSSLUtilTest.java
+++ b/server/test/com/mirth/connect/util/MirthSSLUtilTest.java
@@ -29,11 +29,9 @@ public class MirthSSLUtilTest {
         String[] enabledClientProtocols = MirthSSLUtil.getEnabledHttpsProtocols(defaultClientProtocols);
         String[] enabledServerProtocols = MirthSSLUtil.getEnabledHttpsProtocols(defaultServerProtocols);
 
-        // TLSv1.3 supported in Java 11+
-        if (getJavaVersion() >= 11) {
-            assertTrue(ArrayUtils.contains(enabledClientProtocols, "TLSv1.3"));
-            assertTrue(ArrayUtils.contains(enabledServerProtocols, "TLSv1.3"));
-        }
+        // TLSv1.3 supported in Java 8u261+
+        assertTrue(ArrayUtils.contains(enabledClientProtocols, "TLSv1.3"));
+        assertTrue(ArrayUtils.contains(enabledServerProtocols, "TLSv1.3"));
     }
 
     @Test
@@ -44,10 +42,8 @@ public class MirthSSLUtilTest {
 
         String[] enabledClientCipherSuites = MirthSSLUtil.getEnabledHttpsCipherSuites(defaultClientCipherSuites);
 
-        // TLS_AES_256_GCM_SHA384 supported in Java 11+
-        if (getJavaVersion() >= 11) {
-            assertTrue(ArrayUtils.contains(enabledClientCipherSuites, "TLS_AES_256_GCM_SHA384"));
-        }
+        // TLS_AES_256_GCM_SHA384 supported in Java 8u261+
+        assertTrue(ArrayUtils.contains(enabledClientCipherSuites, "TLS_AES_256_GCM_SHA384"));
     }
 
     private int getJavaVersion() {

--- a/server/test/com/mirth/connect/util/MirthSSLUtilTest.java
+++ b/server/test/com/mirth/connect/util/MirthSSLUtilTest.java
@@ -33,9 +33,6 @@ public class MirthSSLUtilTest {
         if (getJavaVersion() >= 11) {
             assertTrue(ArrayUtils.contains(enabledClientProtocols, "TLSv1.3"));
             assertTrue(ArrayUtils.contains(enabledServerProtocols, "TLSv1.3"));
-        } else {
-            assertFalse(ArrayUtils.contains(enabledClientProtocols, "TLSv1.3"));
-            assertFalse(ArrayUtils.contains(enabledServerProtocols, "TLSv1.3"));
         }
     }
 
@@ -50,8 +47,6 @@ public class MirthSSLUtilTest {
         // TLS_AES_256_GCM_SHA384 supported in Java 11+
         if (getJavaVersion() >= 11) {
             assertTrue(ArrayUtils.contains(enabledClientCipherSuites, "TLS_AES_256_GCM_SHA384"));
-        } else {
-            assertFalse(ArrayUtils.contains(enabledClientCipherSuites, "TLS_AES_256_GCM_SHA384"));
         }
     }
 


### PR DESCRIPTION
Related #144 