### PR TITLE
Suppress warnings about java security manager

### DIFF
--- a/client/src/com/mirth/connect/client/ui/OSXAdapter.java
+++ b/client/src/com/mirth/connect/client/ui/OSXAdapter.java
@@ -278,6 +278,7 @@ public class OSXAdapter implements InvocationHandler {
         return macOSXApplication;
     }
 
+    @SuppressWarnings("removal")
     protected static void setHandler(InvocationHandler adapter, String interfaceName, String applicationSetter) throws Exception {
         Class<?> handlerInterface = Class.forName(interfaceName);
         Object handlerImpl = Proxy.newProxyInstance(AccessController.doPrivileged(ReflectionHelper.getClassLoaderPA(handlerInterface)), new Class[] {

--- a/client/src/com/mirth/connect/client/ui/panels/connectors/ConnectorSettingsPanel.java
+++ b/client/src/com/mirth/connect/client/ui/panels/connectors/ConnectorSettingsPanel.java
@@ -197,7 +197,7 @@ public abstract class ConnectorSettingsPanel extends JPanel {
      *            A custom error message to display if an exception occurs during connector service
      *            invocation
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"removal", "unchecked"})
     public final <T> T getServlet(final Class<T> servletInterface, final String workerDisplayText, final String errorText, final ResponseHandler responseHandler, final String workerId) {
         return (T) Proxy.newProxyInstance(AccessController.doPrivileged(ReflectionHelper.getClassLoaderPA(servletInterface)), new Class[] {
                 servletInterface }, new InvocationHandler() {

--- a/server/src/com/mirth/connect/client/core/Client.java
+++ b/server/src/com/mirth/connect/client/core/Client.java
@@ -243,7 +243,7 @@ public class Client implements UserServletInterface, ConfigurationServletInterfa
         return getServlet(servletInterface, executeType, null);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"removal", "unchecked"})
     public <T> T getServlet(final Class<T> servletInterface, final ExecuteType executeType, final Map<String, List<String>> customHeaders) {
         return (T) Proxy.newProxyInstance(AccessController.doPrivileged(ReflectionHelper.getClassLoaderPA(servletInterface)), new Class[] {
                 servletInterface }, new InvocationHandler() {

--- a/server/src/com/mirth/connect/server/util/javascript/MirthJavaScriptThreadFactory.java
+++ b/server/src/com/mirth/connect/server/util/javascript/MirthJavaScriptThreadFactory.java
@@ -18,6 +18,7 @@ public class MirthJavaScriptThreadFactory implements ThreadFactory {
     private final AtomicInteger threadNumber = new AtomicInteger(1);
     private final String namePrefix;
 
+    @SuppressWarnings("removal")
     MirthJavaScriptThreadFactory() {
         SecurityManager securityManager = System.getSecurityManager();
         group = (securityManager != null) ? securityManager.getThreadGroup() : Thread.currentThread().getThreadGroup();

--- a/server/src/org/glassfish/jersey/client/proxy/WebResourceFactory.java
+++ b/server/src/org/glassfish/jersey/client/proxy/WebResourceFactory.java
@@ -140,7 +140,7 @@ public final class WebResourceFactory implements InvocationHandler {
      * @return Instance of a class implementing the resource interface that can
      * be used for making requests to the server.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"removal", "unchecked"})
     public static <C> C newResource(final Class<C> resourceInterface,
                                     final WebTarget target,
                                     final boolean ignoreResourcePath,


### PR DESCRIPTION
Suppresses javac build warnings present on Java 8 and Java 17.

Split from https://github.com/OpenIntegrationEngine/engine/pull/152