### PR TITLE
Update NCPDP display name

### DIFF
--- a/client/src/com/mirth/connect/plugins/datatypes/ncpdp/NCPDPDataTypeClientPlugin.java
+++ b/client/src/com/mirth/connect/plugins/datatypes/ncpdp/NCPDPDataTypeClientPlugin.java
@@ -26,7 +26,7 @@ public class NCPDPDataTypeClientPlugin extends DataTypeClientPlugin {
 
     @Override
     public String getDisplayName() {
-        return "NCPDP";
+        return "NCPDP Telecom";
     }
 
     @Override

--- a/client/src/com/mirth/connect/plugins/datatypes/ncpdp/NCPDPDataTypeCodeTemplatePlugin.java
+++ b/client/src/com/mirth/connect/plugins/datatypes/ncpdp/NCPDPDataTypeCodeTemplatePlugin.java
@@ -25,6 +25,6 @@ public class NCPDPDataTypeCodeTemplatePlugin extends DataTypeCodeTemplatePlugin 
 
     @Override
     protected String getDisplayName() {
-        return "NCPDP";
+        return "NCPDP Telecom";
     }
 }


### PR DESCRIPTION
NCPDP is the name of a standards body.  The format supported by OIE is NCPDP Telecom (Versions 5.0, 5.1, D.0).

<img width="317" height="423" alt="Screenshot showing updated datatype drop-down" src="https://github.com/user-attachments/assets/bb8f39f3-08c6-4d8e-86c1-8df4dfce8d35" />

Only DisplayName updated to avoid compat issues.  Classes and name from FormatterFactory not updated.