### PR TITLE
change alias name in the JKS store

### DIFF
--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -1517,7 +1517,7 @@ public class DefaultConfigurationController extends ConfigurationController {
      * 
      */
     private void generateDefaultCertificate(Provider provider, KeyStore keyStore, char[] keyPassword) throws Exception {
-        final String certificateAlias = "mirthconnect";
+        final String certificateAlias = "oiengine";
 
         if (!keyStore.containsAlias(certificateAlias)) {
             // Common CA and SSL cert attributes


### PR DESCRIPTION
Follow a discussion on discord about use SSL/TLS without error about the certificate verification, i see the alias name is mirthconnect, i replace it with **oiengine**

<img width="850" height="146" alt="javaw_VUGY6gRcIq" src="https://github.com/user-attachments/assets/cbcfd3d1-ed73-422e-8cad-97f1d320183f" />
