### PR TITLE
Allow specifying a proxy for http API connections

### DIFF
--- a/server/src/com/mirth/connect/client/core/ServerConnection.java
+++ b/server/src/com/mirth/connect/client/core/ServerConnection.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
@@ -91,6 +92,8 @@ public class ServerConnection implements Connector {
     public static final String EXECUTE_TYPE_PROPERTY = "executeType";
     public static final String OPERATION_PROPERTY = "operation";
     public static final String CUSTOM_HEADERS_PROPERTY = "customHeaders";
+    private static final String PROXY_HOST_PROPERTY = "engine.http.proxyHost";
+    private static final String PROXY_PORT_PROPERTY = "engine.http.proxyPort";
 
     private static final int CONNECT_TIMEOUT = 10000;
     private static final int IDLE_TIMEOUT = 300000;
@@ -134,7 +137,21 @@ public class ServerConnection implements Connector {
 
         cookieStore = new BasicCookieStore();
         socketConfig = SocketConfig.custom().setSoTimeout(timeout).build();
-        requestConfig = RequestConfig.custom().setConnectTimeout(CONNECT_TIMEOUT).setSocketTimeout(timeout).build();
+
+        RequestConfig.Builder requestConfigBuilder = RequestConfig.custom()
+            .setConnectTimeout(CONNECT_TIMEOUT)
+            .setSocketTimeout(timeout);
+
+        // If HTTP Proxy is set, configure it
+        String httpProxyHost = System.getProperty(PROXY_HOST_PROPERTY);
+        if (allowHTTP && StringUtils.isNotBlank(httpProxyHost)) {
+            String httpProxyPort = System.getProperty(PROXY_PORT_PROPERTY);
+            int proxyPort = StringUtils.isNotBlank(httpProxyPort) ? Integer.parseInt(httpProxyPort) : 8888;
+            logger.info("Using API HTTP Proxy {}:{}", httpProxyHost, proxyPort);
+            requestConfigBuilder.setProxy(new HttpHost(httpProxyHost, proxyPort));
+        }
+
+        requestConfig = requestConfigBuilder.build();
         keepAliveStrategy = new CustomKeepAliveStrategy();
 
         createClient();


### PR DESCRIPTION
Allow specifying a proxy for http API connections via mirthApi.http.proxyHost.  

Example invocation: `-DmirthApi.http.proxyHost=127.0.0.1`.  [Example file attached](https://github.com/user-attachments/files/22985546/1687_Full.txt) showing login with no channels.

Example with Fiddler:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b5cd5e72-3e6b-418c-9c3d-76f851631e19" />

Closes #190 