### PR TITLE
Fix ant warnings on build for missing dirs

### DIFF
--- a/server/build.xml
+++ b/server/build.xml
@@ -141,7 +141,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.dicom}/lib" failonerror="false">
+		<copy todir="${connectors.dicom}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/dimse" />
 		</copy>
 		<jar destfile="${connectors.dicom}/dicom-shared.jar" basedir="${classes}">
@@ -164,7 +164,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.doc}/lib" failonerror="false">
+		<copy todir="${connectors.doc}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/doc" />
 		</copy>
 		<jar destfile="${connectors.doc}/doc-shared.jar" basedir="${classes}">
@@ -190,7 +190,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.file}/lib" failonerror="false">
+		<copy todir="${connectors.file}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/file" />
 		</copy>
 		<jar destfile="${connectors.file}/file-shared.jar" basedir="${classes}">
@@ -228,7 +228,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.http}/lib" failonerror="false">
+		<copy todir="${connectors.http}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/http" />
 		</copy>
 		<jar destfile="${connectors.http}/http-shared.jar" basedir="${classes}">
@@ -256,7 +256,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.jdbc}/lib" failonerror="false">
+		<copy todir="${connectors.jdbc}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/jdbc" />
 		</copy>
 		<jar destfile="${connectors.jdbc}/jdbc-shared.jar" basedir="${classes}">
@@ -286,7 +286,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.jms}/lib" failonerror="false">
+		<copy todir="${connectors.jms}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/jms" />
 		</copy>
 		<jar destfile="${connectors.jms}/jms-shared.jar" basedir="${classes}">
@@ -312,7 +312,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.js}/lib" failonerror="false">
+		<copy todir="${connectors.js}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/js" />
 		</copy>
 		<jar destfile="${connectors.js}/js-shared.jar" basedir="${classes}">
@@ -334,7 +334,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.smtp}/lib" failonerror="false">
+		<copy todir="${connectors.smtp}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/smtp" />
 		</copy>
 		<jar destfile="${connectors.smtp}/smtp-shared.jar" basedir="${classes}">
@@ -358,7 +358,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.tcp}/lib" failonerror="false">
+		<copy todir="${connectors.tcp}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/tcp" />
 		</copy>
 		<jar destfile="${connectors.tcp}/tcp-shared.jar" basedir="${classes}">
@@ -382,7 +382,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.vm}/lib" failonerror="false">
+		<copy todir="${connectors.vm}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/vm" />
 		</copy>
 		<jar destfile="${connectors.vm}/vm-shared.jar" basedir="${classes}">
@@ -404,7 +404,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${connectors.ws}/lib" failonerror="false">
+		<copy todir="${connectors.ws}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/ws" />
 		</copy>
 		<jar destfile="${connectors.ws}/ws-shared.jar" basedir="${classes}">
@@ -443,7 +443,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-delimited}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-delimited}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/delimited" />
 		</copy>
 		<jar destfile="${plugins.datatype-delimited}/datatype-delimited-shared.jar" basedir="${classes}">
@@ -465,7 +465,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-dicom}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-dicom}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/dicom" />
 		</copy>
 		<jar destfile="${plugins.datatype-dicom}/datatype-dicom-shared.jar" basedir="${classes}">
@@ -484,7 +484,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-edi}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-edi}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/edi" />
 		</copy>
 		<!-- copy the xml files so they will be included in jar -->
@@ -506,7 +506,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-hl7v2}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-hl7v2}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/hl7v2" />
 		</copy>
 		<jar destfile="${plugins.datatype-hl7v2}/datatype-hl7v2-shared.jar" basedir="${classes}">
@@ -526,7 +526,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-hl7v3}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-hl7v3}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/hl7v3" />
 		</copy>
 		<jar destfile="${plugins.datatype-hl7v3}/datatype-hl7v3-shared.jar" basedir="${classes}">
@@ -544,7 +544,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-ncpdp}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-ncpdp}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/ncpdp" />
 		</copy>
 		<jar destfile="${plugins.datatype-ncpdp}/datatype-ncpdp-shared.jar" basedir="${classes}">
@@ -562,7 +562,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-xml}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-xml}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/xml" />
 		</copy>
 		<jar destfile="${plugins.datatype-xml}/datatype-xml-shared.jar" basedir="${classes}">
@@ -580,7 +580,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-raw}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-raw}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/raw" />
 		</copy>
 		<jar destfile="${plugins.datatype-raw}/datatype-raw-shared.jar" basedir="${classes}">
@@ -598,7 +598,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datatype-json}/lib" failonerror="false">
+		<copy todir="${plugins.datatype-json}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datatypes/json" />
 		</copy>
 		<jar destfile="${plugins.datatype-json}/datatype-json-shared.jar" basedir="${classes}">
@@ -616,7 +616,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.directoryresource}/lib" failonerror="false">
+		<copy todir="${plugins.directoryresource}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/directoryresource" />
 		</copy>
 		<jar destfile="${plugins.directoryresource}/directoryresource-shared.jar" basedir="${classes}">
@@ -636,7 +636,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.dashboardstatus}/lib" failonerror="false">
+		<copy todir="${plugins.dashboardstatus}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/dashboardstatus" />
 		</copy>
 		<jar destfile="${plugins.dashboardstatus}/dashboardstatus-shared.jar" basedir="${classes}">
@@ -656,7 +656,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.destinationsetfilter}/lib" failonerror="false">
+		<copy todir="${plugins.destinationsetfilter}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/destinationsetfilter" />
 		</copy>
 		<jar destfile="${plugins.destinationsetfilter}/destinationsetfilter-shared.jar" basedir="${classes}">
@@ -672,7 +672,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.dicomviewer}/lib" failonerror="false">
+		<copy todir="${plugins.dicomviewer}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/dicomviewer" />
 		</copy>
 		
@@ -683,7 +683,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.globalmapviewer}/lib" failonerror="false">
+		<copy todir="${plugins.globalmapviewer}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/globalmapviewer" />
 		</copy>
 		<jar destfile="${plugins.globalmapviewer}/globalmapviewer-shared.jar" basedir="${classes}">
@@ -701,7 +701,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.httpauth}/lib" failonerror="false">
+		<copy todir="${plugins.httpauth}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/httpauth" />
 		</copy>
 		<jar destfile="${plugins.httpauth}/httpauth-shared.jar" basedir="${classes}">
@@ -742,7 +742,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.imageviewer}/lib" failonerror="false">
+		<copy todir="${plugins.imageviewer}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/imageviewer" />
 		</copy>
 
@@ -753,7 +753,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.javascriptrule}/lib" failonerror="false">
+		<copy todir="${plugins.javascriptrule}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/javascriptrule" />
 		</copy>
 		<jar destfile="${plugins.javascriptrule}/javascriptrule-shared.jar" basedir="${classes}">
@@ -767,7 +767,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.javascriptstep}/lib" failonerror="false">
+		<copy todir="${plugins.javascriptstep}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/javascriptstep" />
 		</copy>
 		<jar destfile="${plugins.javascriptstep}/javascriptstep-shared.jar" basedir="${classes}">
@@ -781,7 +781,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.mapper}/lib" failonerror="false">
+		<copy todir="${plugins.mapper}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/mapper" />
 		</copy>
 		<jar destfile="${plugins.mapper}/mapper-shared.jar" basedir="${classes}">
@@ -796,7 +796,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.messagebuilder}/lib" failonerror="false">
+		<copy todir="${plugins.messagebuilder}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/messagebuilder" />
 		</copy>
 		<jar destfile="${plugins.messagebuilder}/messagebuilder-shared.jar" basedir="${classes}">
@@ -810,7 +810,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.datapruner}/lib" failonerror="false">
+		<copy todir="${plugins.datapruner}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/datapruner" />
 		</copy>
 		<jar destfile="${plugins.datapruner}/datapruner-shared.jar" basedir="${classes}">
@@ -828,7 +828,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.mllpmode}/lib" failonerror="false">
+		<copy todir="${plugins.mllpmode}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/mllpmode" />
 		</copy>
 		<jar destfile="${plugins.mllpmode}/mllpmode-shared.jar" basedir="${classes}">
@@ -846,7 +846,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.pdfviewer}/lib" failonerror="false">
+		<copy todir="${plugins.pdfviewer}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/pdfviewer" />
 		</copy>
 
@@ -857,7 +857,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.textviewer}/lib" failonerror="false">
+		<copy todir="${plugins.textviewer}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/textviewer" />
 		</copy>
 
@@ -868,7 +868,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.rulebuilder}/lib" failonerror="false">
+		<copy todir="${plugins.rulebuilder}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/rulebuilder" />
 		</copy>
 		<jar destfile="${plugins.rulebuilder}/rulebuilder-shared.jar" basedir="${classes}">
@@ -883,7 +883,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.serverlog}/lib" failonerror="false">
+		<copy todir="${plugins.serverlog}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/serverlog" />
 		</copy>
 		<jar destfile="${plugins.serverlog}/serverlog-shared.jar" basedir="${classes}">
@@ -903,7 +903,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.scriptfilerule}/lib" failonerror="false">
+		<copy todir="${plugins.scriptfilerule}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/scriptfilerule" />
 		</copy>
 		<jar destfile="${plugins.scriptfilerule}/scriptfilerule-shared.jar" basedir="${classes}">
@@ -917,7 +917,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.scriptfilestep}/lib" failonerror="false">
+		<copy todir="${plugins.scriptfilestep}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/scriptfilestep" />
 		</copy>
 		<jar destfile="${plugins.scriptfilestep}/scriptfilestep-shared.jar" basedir="${classes}">
@@ -931,7 +931,7 @@
 				<include name="*.xml" />
 			</fileset>
 		</copy>
-		<copy todir="${plugins.xsltstep}/lib" failonerror="false">
+		<copy todir="${plugins.xsltstep}/lib" failonerror="false" quiet="true">
 			<fileset dir="${lib.extensions}/xsltstep" />
 		</copy>
 		<jar destfile="${plugins.xsltstep}/xsltstep-shared.jar" basedir="${classes}">


### PR DESCRIPTION
Addresses or silences warnings present in build to front-load the Java 17 migration.

Related: #146