### PR TITLE
Add missing javadoc for User API classes

### DIFF
--- a/server/src/com/mirth/connect/server/userutil/DatabaseConnectionFactory.java
+++ b/server/src/com/mirth/connect/server/userutil/DatabaseConnectionFactory.java
@@ -31,6 +31,12 @@ public class DatabaseConnectionFactory {
     private Map<String, CustomDriverInfo> customDriverInfoMap;
     private Logger logger = LogManager.getLogger(getClass());
 
+    /**
+     * Instantiates a new DatabaseConnectionFactory with the specified MirthContextFactory.
+     * 
+     * @param contextFactory
+     *            The MirthContextFactory to use when creating database connections.
+     */
     public DatabaseConnectionFactory(MirthContextFactory contextFactory) {
         this.contextFactory = contextFactory;
     }

--- a/server/src/com/mirth/connect/server/userutil/DeployedState.java
+++ b/server/src/com/mirth/connect/server/userutil/DeployedState.java
@@ -16,7 +16,28 @@ import org.apache.commons.lang3.text.WordUtils;
  * STOPPED
  */
 public enum DeployedState {
-    UNDEPLOYED, DEPLOYING, UNDEPLOYING, STARTING, STARTED, PAUSING, PAUSED, STOPPING, STOPPED, SYNCING, UNKNOWN;
+    /** The channel is disabled or not yet deployed. */
+    UNDEPLOYED, 
+    /** The channel is in the process of being deployed. */
+    DEPLOYING, 
+    /** The channel is in the process of being undeployed. */
+    UNDEPLOYING, 
+    /** The channel is in the process of starting. */
+    STARTING, 
+    /** The channel is running. */
+    STARTED, 
+    /** The channel is in the process of pausing. */
+    PAUSING, 
+    /** The channel is paused. */
+    PAUSED, 
+    /** The channel is in the process of stopping. */
+    STOPPING, 
+    /** The channel is stopped. */
+    STOPPED, 
+    /** The channel is in the process of syncing. */
+    SYNCING, 
+    /** The channel state is unknown. */
+    UNKNOWN;
 
     private DeployedState() {}
 

--- a/server/src/com/mirth/connect/server/userutil/EncryptedData.java
+++ b/server/src/com/mirth/connect/server/userutil/EncryptedData.java
@@ -17,6 +17,15 @@ public class EncryptedData {
     private String header;
     private byte[] encryptedData;
 
+    /**
+     * Instantiates a new EncryptedData object with the specified header and encrypted data.
+     * 
+     * @param header
+     *            The meta-information about the encrypted data, including the algorithm and
+     *            initialization vector used.
+     * @param encryptedData
+     *            The encrypted data as a byte array.
+     */
     public EncryptedData(String header, byte[] encryptedData) {
         this.header = header;
         this.encryptedData = encryptedData;
@@ -25,6 +34,8 @@ public class EncryptedData {
     /**
      * Returns the meta-information about the encrypted data. Includes the algorithm and
      * initialization vector used.
+     * 
+     * @return The header information as a string.
      */
     public String getHeader() {
         return header;
@@ -32,6 +43,8 @@ public class EncryptedData {
 
     /**
      * Returns the encrypted data as a byte array.
+     * 
+     * @return The encrypted data.
      */
     public byte[] getEncryptedData() {
         return encryptedData;

--- a/server/src/com/mirth/connect/server/userutil/MirthCachedRowSet.java
+++ b/server/src/com/mirth/connect/server/userutil/MirthCachedRowSet.java
@@ -56,6 +56,12 @@ public class MirthCachedRowSet implements CachedRowSet {
     private RowSetMetaDataImpl RowSetMD;
     private CachedRowSet delegate = RowSetProvider.newFactory().createCachedRowSet();
 
+    /**
+     * Instantiates a new MirthCachedRowSet object.
+     * 
+     * @throws SQLException
+     *             If a database access error occurs.
+     */
     public MirthCachedRowSet() throws SQLException {
         super();
     }

--- a/server/src/com/mirth/connect/server/userutil/SourceMap.java
+++ b/server/src/com/mirth/connect/server/userutil/SourceMap.java
@@ -16,6 +16,9 @@ import java.util.Set;
 
 import com.mirth.connect.donkey.server.Constants;
 
+/**
+ * Collection implementing the Source Map.
+ */
 public class SourceMap implements Map<String, Object> {
 
     private Map<String, Object> delegate;

--- a/server/src/com/mirth/connect/userutil/AttachmentEntry.java
+++ b/server/src/com/mirth/connect/userutil/AttachmentEntry.java
@@ -19,8 +19,11 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
  * Web Service Sender, the variable must reference a list of AttachmentEntry objects.
  */
 public class AttachmentEntry implements Serializable {
+    /** The name of the attachment entry. */
     private String name;
+    /** The content of the attachment entry. */
     private String content;
+    /** The MIME type of the attachment entry. */
     private String mimeType;
 
     /**

--- a/server/src/com/mirth/connect/userutil/ContentType.java
+++ b/server/src/com/mirth/connect/userutil/ContentType.java
@@ -19,7 +19,36 @@ import org.apache.commons.lang3.text.WordUtils;
  * POSTPROCESSOR_ERROR, RESPONSE_ERROR, SOURCE_MAP
  */
 public enum ContentType {
-    RAW, PROCESSED_RAW, TRANSFORMED, ENCODED, SENT, RESPONSE, RESPONSE_TRANSFORMED, PROCESSED_RESPONSE, CONNECTOR_MAP, CHANNEL_MAP, RESPONSE_MAP, PROCESSING_ERROR, POSTPROCESSOR_ERROR, RESPONSE_ERROR, SOURCE_MAP;
+    /** The inbound message as received by the channel after attachment extraction but before preprocessor modification. */
+    RAW,
+    /** The inbound message after preprocessor script execution. */
+    PROCESSED_RAW,
+    /** The internal representation of the message after transformer execution. */
+    TRANSFORMED,
+    /** The message data deserialized from transformed data into the outbound data type. */
+    ENCODED,
+    /** Snapshot of destination connector properties before message dispatch attempt. */
+    SENT,
+    /** The response object returned by the destination connector after dispatch attempt. */
+    RESPONSE,
+    /** The internal representation of response content serialized into the response inbound data type. */
+    RESPONSE_TRANSFORMED,
+    /** The response content deserialized from internal representation into the response outbound data type. */
+    PROCESSED_RESPONSE,
+    /** Map containing connector-specific variables and data. */
+    CONNECTOR_MAP,
+    /** Map containing channel-specific variables and data. */
+    CHANNEL_MAP,
+    /** Map containing response-specific variables and data. */
+    RESPONSE_MAP,
+    /** Content containing error information from message processing. */
+    PROCESSING_ERROR,
+    /** Content containing error information from postprocessor execution. */
+    POSTPROCESSOR_ERROR,
+    /** Content containing error information from response processing. */
+    RESPONSE_ERROR,
+    /** Map containing source connector variables and data. */
+    SOURCE_MAP;
 
     private ContentType() {}
 

--- a/server/src/com/mirth/connect/userutil/MessageHeaders.java
+++ b/server/src/com/mirth/connect/userutil/MessageHeaders.java
@@ -18,10 +18,20 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * A wrapper around a Map of HTTP headers that provides convenience methods for accessing header
+ * values.
+ */
 public class MessageHeaders {
     private static Logger logger = LogManager.getLogger(MessageHeaders.class);
     private Map<String, List<String>> delegate;
 
+    /**
+     * Instantiates a new MessageHeaders object that wraps the given Map of HTTP headers.
+     * 
+     * @param delegate
+     *            The Map of HTTP headers to wrap.
+     */
     public MessageHeaders(Map<String, List<String>> delegate) {
         this.delegate = delegate;
     }

--- a/server/src/com/mirth/connect/userutil/MessageParameters.java
+++ b/server/src/com/mirth/connect/userutil/MessageParameters.java
@@ -18,10 +18,20 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * A wrapper around a Map of HTTP parameters that provides convenience methods for accessing
+ * parameter values.
+ */
 public class MessageParameters {
     private static Logger logger = LogManager.getLogger(MessageParameters.class);
     private Map<String, List<String>> delegate;
 
+    /**
+     * Instantiates a new MessageParameters object that wraps the given Map of HTTP parameters.
+     * 
+     * @param delegate
+     *            The Map of HTTP parameters to wrap.
+     */
     public MessageParameters(Map<String, List<String>> delegate) {
         this.delegate = delegate;
     }

--- a/server/src/com/mirth/connect/userutil/Status.java
+++ b/server/src/com/mirth/connect/userutil/Status.java
@@ -15,7 +15,20 @@ package com.mirth.connect.userutil;
  * RECEIVED, FILTERED, TRANSFORMED, SENT, QUEUED, ERROR, PENDING
  */
 public enum Status {
-    RECEIVED, FILTERED, TRANSFORMED, SENT, QUEUED, ERROR, PENDING;
+    /** The message has been received by the connector. */
+    RECEIVED,
+    /** The message has been filtered by the connector. */
+    FILTERED,
+    /** The message has been transformed by the connector. */
+    TRANSFORMED,
+    /** The message has been sent by the connector and received a successful response. */
+    SENT,
+    /** The message is queued for processing. */
+    QUEUED,
+    /** The message has encountered an error. */
+    ERROR,
+    /** The message is pending processing. */
+    PENDING;
 
     private Status() {}
 


### PR DESCRIPTION
Separated from https://github.com/OpenIntegrationEngine/engine/pull/200 and https://github.com/OpenIntegrationEngine/engine/pull/146

Several of the User API classes were lacking complete javadoc comments, which was triggering some warnings during build. Of course it is useful to have these, which is why it was warning in the first place.