### PR TITLE
Add tests for calendar converter and server log item

### DIFF
--- a/server/test/com/mirth/connect/client/core/api/providers/CalendarParamConverterProviderTest.java
+++ b/server/test/com/mirth/connect/client/core/api/providers/CalendarParamConverterProviderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ * 
+ * http://www.mirthcorp.com
+ * 
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.client.core.api.providers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.ext.ParamConverter;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CalendarParamConverterProviderTest {
+
+    private static ParamConverter<Calendar> converter;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    @BeforeClass
+    @SuppressWarnings("unchecked")
+    public static void setup() {
+        converter = (ParamConverter<Calendar>) new CalendarParamConverterProvider().getConverter(Calendar.class, null,
+                null);
+    }
+
+    @Test
+    public void testGetConverter() {
+        CalendarParamConverterProvider provider = new CalendarParamConverterProvider();
+        assertNotNull(provider.getConverter(Calendar.class, null, null));
+        assertNull(provider.getConverter(String.class, null, null));
+    }
+
+    @Test
+    public void testFromStringValid() {
+        String dateString = "2023-10-27T10:30:00.000-0400";
+        Calendar calendar = converter.fromString(dateString);
+        assertNotNull(calendar);
+
+        ZonedDateTime zdt = ZonedDateTime.parse(dateString, FORMATTER);
+        assertEquals(zdt.toInstant().toEpochMilli(), calendar.getTimeInMillis());
+        assertEquals(zdt.getZone().getId(), calendar.getTimeZone().getID());
+    }
+
+    @Test
+    public void testFromStringNull() {
+        assertNull(converter.fromString(null));
+    }
+
+    @Test(expected = ProcessingException.class)
+    public void testFromStringInvalidFormat() {
+        converter.fromString("invalid-date-string");
+    }
+
+    @Test
+    public void testRoundTrip() {
+        Calendar original = Calendar.getInstance(TimeZone.getTimeZone("America/New_York"));
+        original.set(2023, Calendar.DECEMBER, 25, 9, 0, 0);
+        original.set(Calendar.MILLISECOND, 0);
+
+        String stringValue = converter.toString(original);
+        Calendar result = converter.fromString(stringValue);
+
+        assertEquals(original.getTimeInMillis(), result.getTimeInMillis());
+        assertEquals(original.getTimeZone().getID(), result.getTimeZone().getID());
+    }
+
+    @Test
+    public void testTimezonePreservation() {
+        String[] zoneIds = { "UTC", "America/Los_Angeles", "Europe/London", "Asia/Tokyo" };
+
+        for (String zoneId : zoneIds) {
+            Calendar original = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
+            String stringValue = converter.toString(original);
+            Calendar result = converter.fromString(stringValue);
+
+            assertEquals("Failed for timezone: " + zoneId, original.getTimeZone().getID(),
+                    result.getTimeZone().getID());
+            assertEquals("Failed for timezone: " + zoneId, original.getTimeInMillis(), result.getTimeInMillis());
+        }
+    }
+}

--- a/server/test/com/mirth/connect/plugins/serverlog/ServerLogItemTest.java
+++ b/server/test/com/mirth/connect/plugins/serverlog/ServerLogItemTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ * 
+ * http://www.mirthcorp.com
+ * 
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.plugins.serverlog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Date;
+
+import org.junit.Test;
+
+public class ServerLogItemTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        ServerLogItem item = new ServerLogItem();
+        assertNull(item.getServerId());
+        assertNull(item.getId());
+        assertNull(item.getLevel());
+        assertNull(item.getDate());
+        assertNull(item.getThreadName());
+        assertNull(item.getCategory());
+        assertNull(item.getLineNumber());
+        assertNull(item.getMessage());
+        assertNull(item.getThrowableInformation());
+    }
+
+    @Test
+    public void testMessageConstructor() {
+        String message = "Test Message";
+        ServerLogItem item = new ServerLogItem(message);
+        assertEquals(message, item.getMessage());
+        assertNull(item.getId());
+    }
+
+    @Test
+    public void testFullConstructor() {
+        String serverId = "server-1";
+        Long id = 100L;
+        String level = "INFO";
+        Date date = new Date();
+        String threadName = "main";
+        String category = "com.test";
+        String lineNumber = "123";
+        String message = "Test Message";
+        String throwableInfo = "Exception stack trace";
+
+        ServerLogItem item = new ServerLogItem(serverId, id, level, date, threadName, category, lineNumber, message,
+                throwableInfo);
+
+        assertEquals(serverId, item.getServerId());
+        assertEquals(id, item.getId());
+        assertEquals(level, item.getLevel());
+        assertEquals(date, item.getDate());
+        assertEquals(threadName, item.getThreadName());
+        assertEquals(category, item.getCategory());
+        assertEquals(lineNumber, item.getLineNumber());
+        assertEquals(message, item.getMessage());
+        assertEquals(throwableInfo, item.getThrowableInformation());
+    }
+
+    @Test
+    public void testSetters() {
+        ServerLogItem item = new ServerLogItem();
+
+        item.setServerId("server-1");
+        item.setId(1L);
+        item.setLevel("ERROR");
+        Date date = new Date();
+        item.setDate(date);
+        item.setThreadName("thread-1");
+        item.setCategory("category");
+        item.setLineNumber("50");
+        item.setMessage("message");
+        item.setThrowableInformation("stacktrace");
+
+        assertEquals("server-1", item.getServerId());
+        assertEquals(Long.valueOf(1), item.getId());
+        assertEquals("ERROR", item.getLevel());
+        assertEquals(date, item.getDate());
+        assertEquals("thread-1", item.getThreadName());
+        assertEquals("category", item.getCategory());
+        assertEquals("50", item.getLineNumber());
+        assertEquals("message", item.getMessage());
+        assertEquals("stacktrace", item.getThrowableInformation());
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        ServerLogItem original = new ServerLogItem("server-1", 1L, "INFO", new Date(), "main", "cat", "10", "msg",
+                "err");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(original);
+        oos.close();
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        ServerLogItem deserialized = (ServerLogItem) ois.readObject();
+
+        assertEquals(original.getServerId(), deserialized.getServerId());
+        assertEquals(original.getId(), deserialized.getId());
+        assertEquals(original.getMessage(), deserialized.getMessage());
+        assertEquals(original.getDate(), deserialized.getDate());
+    }
+}


### PR DESCRIPTION
Adds unit tests to validate date handling and logging item behavior.

- Verifies calendar param converter correctly parses and formats RFC-like timestamps, preserves timezones, handles nulls, rejects invalid input, and supports round-trip conversions.
- Exercises server log item: default and full constructors, setters, and Java serialization to ensure fields are correctly stored and restored.

Signed-off-by: Nico Piel <nico.piel@hotmail.de>
