### PR TITLE
Add tooltip for sourceChannelId map

### DIFF
--- a/client/src/com/mirth/connect/client/ui/browsers/message/MessageBrowser.java
+++ b/client/src/com/mirth/connect/client/ui/browsers/message/MessageBrowser.java
@@ -1416,7 +1416,7 @@ public class MessageBrowser extends javax.swing.JPanel {
 
     // Resolve tooltip text for a mapping entry based on key/value
     private String resolveMapValueTooltip(String key, String value) {
-        // Sow channel name when key is sourceChannelId
+        // Show channel name when key is sourceChannelId
         if ("sourceChannelId".equals(key)) {
             return parent.status.stream()
                 .filter(s -> value.equals(s.getChannelId()))


### PR DESCRIPTION
Adds a tooltip to metadata named "sourceChannelId" with the resolved channel name.

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/8417ca52-84c2-4110-8e06-beadf9ac53a9" />

Closes #216