### PR TITLE
AutoClosable Client

### DIFF
--- a/server/src/com/mirth/connect/client/core/Client.java
+++ b/server/src/com/mirth/connect/client/core/Client.java
@@ -131,7 +131,11 @@ import com.mirth.connect.util.MirthSSLUtil;
 import com.mirth.connect.util.messagewriter.EncryptionType;
 import com.mirth.connect.util.messagewriter.MessageWriterOptions;
 
-public class Client implements UserServletInterface, ConfigurationServletInterface, ChannelServletInterface, ChannelGroupServletInterface, ChannelStatusServletInterface, ChannelStatisticsServletInterface, EngineServletInterface, MessageServletInterface, EventServletInterface, AlertServletInterface, CodeTemplateServletInterface, DatabaseTaskServletInterface, UsageServletInterface, ExtensionServletInterface {
+public class Client implements UserServletInterface, ConfigurationServletInterface, ChannelServletInterface,
+        ChannelGroupServletInterface, ChannelStatusServletInterface, ChannelStatisticsServletInterface,
+        EngineServletInterface, MessageServletInterface, EventServletInterface, AlertServletInterface,
+        CodeTemplateServletInterface, DatabaseTaskServletInterface, UsageServletInterface, ExtensionServletInterface,
+        AutoCloseable {
 
     public static final int MAX_QUERY_PARAM_COLLECTION_SIZE = 100;
 
@@ -312,9 +316,9 @@ public class Client implements UserServletInterface, ConfigurationServletInterfa
         this.recorder = recorder;
     }
 
+    @Override
     public void close() {
-        closed.set(true);
-        if (serverConnection != null) {
+        if (!closed.getAndSet(true)) {
             serverConnection.shutdown();
             client.close();
         }


### PR DESCRIPTION
Commit 1
---
    Make several private fields final in Client
    
    These fields are all either initialized in their declarations or in the
    constructor and then never reassigned.

Commit 2
---
    Make Client AutoCloseable and close() idempotent
    
    - Make AutoClosable so it can be used in try-with-resources
    - Removed null check for serverConnection since it cannot be null
    - Do not shutdown serverConnection or close JAX-RS client if this client
      is already closed.