### PR TITLE
Fix Status Not Displaying in Message Filter within Events UI

### DIFF
--- a/server/src/com/mirth/connect/model/MessageFilterToStringStyle.java
+++ b/server/src/com/mirth/connect/model/MessageFilterToStringStyle.java
@@ -41,6 +41,8 @@ public class MessageFilterToStringStyle extends ToStringStyle {
                 }
             }
             buffer.append("]");
+        } else {
+            super.appendDetail(buffer, fieldName, coll);
         }
     }
 }


### PR DESCRIPTION
 The `MessageFilterToStringStyle.appendDetail` collection override only handled `metaDataSearch` and silently
  dropped all other collections, including Status
 
Added fallback to `super.appendDetail()` so Status and other collection fields are properly displayed
 
Closes #250 