### PR TITLE
Add link to administrator launcher options

### DIFF
--- a/server/public_html/index.html
+++ b/server/public_html/index.html
@@ -79,6 +79,14 @@ SPDX-License-Identifier: MPL-2.0
         .api-link:hover {
             transform: scale(1.05);
         }
+        a {
+            color: #f06421;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
         .footer {
             padding: 1rem;
             width: 100%;
@@ -101,6 +109,10 @@ SPDX-License-Identifier: MPL-2.0
         <p>
             Please point your preferred Administrator Launcher to:<br>
             <span id="jnlp-text" class="jnlp-path-container"></span>
+        </p>
+        <p>
+            Don't have an Administrator Launcher yet? Learn about 
+            <a href="https://docs.openintegrationengine.org/launchers/" target="_blank" rel="noopener noreferrer">available launcher options</a>.
         </p>
         <p>
             You can also explore the Client API at the link below.


### PR DESCRIPTION
## Description

Enhanced the server landing page (localhost:8080) to improve the out-of-the-box user experience by adding a documentation link that helps new users discover Administrator Launcher options. The implementation follows vendor-neutral principles by linking to the launcher documentation page (https://docs.openintegrationengine.org/launchers/) rather than hard-coding a specific tool or providing direct download links. Used descriptive link text for better accessibility. Added CSS styling for inline links to ensure visual consistency throughout the landing page.

Closes #168.

## Checklist if Applicable

- [x] The tests passed – Manual testing by opening localhost:8080 and verifying the documentation link appears and links correctly to https://docs.openintegrationengine.org/launchers/
- [ ] Linting passed 
- [ ] Documentation has been added 
- [ ] CHANGELOG.md has been updated 