### PR TITLE
build: add AbstractXMLReader to mirth-client-core

### DIFF
--- a/server/build.xml
+++ b/server/build.xml
@@ -130,6 +130,7 @@
 		<jar destfile="${setup.server.lib}/${client-core.jar}" basedir="${classes}" modificationTime="${archive.entry.date}">
 			<include name="com/mirth/connect/client/core/**" />
 			<include name="com/mirth/connect/model/**" />
+			<include name="org/openintegrationengine/engine/plugins/datatypes/AbstractXMLReader.class" />
 			<include name="com/mirth/connect/userutil/**" />
 			<include name="com/mirth/connect/util/**" />
 			<include name="com/mirth/connect/server/util/ResourceUtil.class" />


### PR DESCRIPTION
This class was not available to the client, but it is required to serialize transformer message templates to the message tree view.