### PR TITLE
fix: use BareBonesBrowserLaunch for Privacy Policy link on all platforms

### DIFF
--- a/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
+++ b/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
@@ -184,13 +184,9 @@ public class FirstLoginDialog extends javax.swing.JDialog implements UserDialogI
         contentTextPane.setEditable(false);
         contentTextPane.addHyperlinkListener(new HyperlinkListener() {
             public void hyperlinkUpdate(HyperlinkEvent evt) {
-                if (evt.getEventType() == EventType.ACTIVATED && Desktop.isDesktopSupported()) {
+                if (evt.getEventType() == EventType.ACTIVATED) {
                     try {
-                        if (Desktop.isDesktopSupported()) {
-                            Desktop.getDesktop().browse(evt.getURL().toURI());
-                        } else {
-                            BareBonesBrowserLaunch.openURL(evt.getURL().toString());
-                        }
+                        BareBonesBrowserLaunch.openURL(evt.getURL().toString());
                     } catch (Exception e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
## Summary
- On some Linux platforms, `Desktop.isDesktopSupported()` returns `true` but `Desktop.getDesktop().browse()` throws an exception, causing the Privacy Policy hyperlink in the first login dialog to silently fail
- Removed the `Desktop` API usage entirely from the hyperlink listener
- Now calls `BareBonesBrowserLaunch.openURL()` directly, which works reliably cross-platform

Fixes #86

## Test plan
- [ ] Click the Privacy Policy link on the first login dialog on Linux — confirm it opens in the default browser
- [ ] Verify the same on Windows and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)