### PR TITLE
Fix log4j2 directory property; add zip compression

### DIFF
--- a/server/conf/log4j2.properties
+++ b/server/conf/log4j2.properties
@@ -1,6 +1,9 @@
 # sample properties to initialize log4j
 rootLogger = ERROR,stdout,fout
 
+# Set a custom variable for the log directory
+property.log.dir = logs
+
 # stdout appender
 appender.console.type = Console
 appender.console.name = stdout
@@ -9,11 +12,10 @@ appender.console.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c: %m%n
 appender.console.layout.charset = UTF-8
 
 # file appender
-dir.logs = logs
 appender.rolling.type = RollingFile
 appender.rolling.name = fout
-appender.rolling.fileName = logs/mirth.log
-appender.rolling.filePattern = logs/mirth.log.%i
+appender.rolling.fileName = ${log.dir}/mirth.log
+appender.rolling.filePattern = ${log.dir}/mirth.log.%i.zip
 appender.rolling.policies.type = Policies
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size = 500KB


### PR DESCRIPTION
The recent log4j2 version bump no longer ignores the invalid and unused line specifying dir.logs causing the server to fail to start.

That line has been removed and converted to a proper log4j2 property, which the file appender now references to allow the user to more easily change the output directory.

Additionally, zip compression was added to the rolling file appender for previous versions.