### PR TITLE
 Fix: Add JavaFX requirement check on startup

### DIFF
--- a/client/src/com/mirth/connect/client/ui/BrandingConstants.java
+++ b/client/src/com/mirth/connect/client/ui/BrandingConstants.java
@@ -30,6 +30,9 @@ public class BrandingConstants {
     // The URL that is opened when clicking "Help" button in Administrator
     public static String HELP_URL_LOCATION = "https://github.com/OpenIntegrationEngine/engine/discussions";
 
+    // The URL that is opened when clicking "System Requirements" button in the error dialog when an unsupported Java version is detected
+    public static final String SYSTEM_REQUIREMENTS_URL = "https://docs.openintegrationengine.org/engine/getting_started.html#system-requirements";
+
     // The "More info" in Server settings "Provide usage statistics"
     public static final String PRIVACY_URL = "https://github.com/openintegrationengine";
     public static final String PRIVACY_TOOLTIP = "Privacy Information";

--- a/client/src/com/mirth/connect/client/ui/ClientPrerequisites.java
+++ b/client/src/com/mirth/connect/client/ui/ClientPrerequisites.java
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Mitch Gaffigan <mitch@gaffigan.net>
+
+package com.mirth.connect.client.ui;
+
+/** Utility class to check if the client prerequisites are met. */
+public class ClientPrerequisites {
+
+    private ClientPrerequisites() {
+    }
+
+    /** Checks if the client prerequisites are met. */
+    public static String getMissing() {
+        // Can't meaningfully check for Java 17 since the entrypoint is compiled with
+        // class file version 61, which will fail to load on Java 8.
+        if (!hasJavaFx()) {
+            return "JavaFX";
+        }
+        
+        return null;
+    }
+
+    private static boolean hasJavaFx() {
+        // Use JPMS to check for JavaFX - the classes are on the classpath
+        // even in Java SE, but the module will not be present except in FX
+        return ModuleLayer.boot().findModule("javafx.graphics").isPresent();
+    }
+}

--- a/client/src/com/mirth/connect/client/ui/Mirth.java
+++ b/client/src/com/mirth/connect/client/ui/Mirth.java
@@ -7,12 +7,14 @@ import java.awt.Color;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.Desktop;
 import java.io.IOException;
 import java.util.prefs.Preferences;
 
 import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
 import javax.swing.InputMap;
+import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
@@ -253,6 +255,13 @@ public class Mirth {
      *            String[]
      */
     public static void main(String[] args) {
+        var missingPrerequisite = ClientPrerequisites.getMissing();
+        if (missingPrerequisite != null) {
+            showUnsupportedJreDialog(missingPrerequisite);
+            System.exit(1);
+            return;
+        }
+
         CommandLineOptions opts = new CommandLineOptions(args);
 
         if (StringUtils.isNotBlank(opts.getProtocols())) {
@@ -265,6 +274,23 @@ public class Mirth {
         PlatformUI.CLIENT_VERSION = opts.getVersion();
 
         start(opts.getServer(), opts.getVersion(), opts.getUsername(), opts.getPassword());
+    }
+
+    private static void showUnsupportedJreDialog(String missingPrerequisite) {
+        try {
+            var message = String.format(
+                "%s Client requires %s%nPlease review the system requirements and try again.",
+                BrandingConstants.PRODUCT_NAME, missingPrerequisite);
+            var options = new Object[] { "View System Requirements", "Exit" };
+            var result = JOptionPane.showOptionDialog(
+                null, message, "Unsupported Java Runtime", JOptionPane.DEFAULT_OPTION, JOptionPane.ERROR_MESSAGE, null, options, options[0]);
+
+            if (result == 0) {
+                Desktop.getDesktop().browse(java.net.URI.create(BrandingConstants.SYSTEM_REQUIREMENTS_URL));
+            }
+        } catch (Throwable t) {
+            System.err.println(String.format("Missing prerequisite: %s", missingPrerequisite));
+        }
     }
 
     private static void start(final String server, final String version, final String username, final String password) {


### PR DESCRIPTION
Adds a startup check to verify the environment is acceptable to the app.  Can't check for java version since we're targeting bytecode 61, but does check Java FX.

Here's the new startup error.

<img width="716" height="304" alt="image" src="https://github.com/user-attachments/assets/4fa7a05e-9961-44ac-b6b6-8dde14a73e25" />

Tested using Azul Zulu JRE 17 FX and SE

Closes #277 