### PR TITLE
Add certificate pinning to address MITM vulnerabilities

### DIFF
--- a/client/src/com/mirth/connect/client/ui/CommandLineOptions.java
+++ b/client/src/com/mirth/connect/client/ui/CommandLineOptions.java
@@ -3,6 +3,10 @@
 
 package com.mirth.connect.client.ui;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -15,57 +19,46 @@ public class CommandLineOptions {
     private final String password;
     private final String protocols;
     private final String cipherSuites;
+    private final String pinnedClientTrust;
 
     /**
      * Parse command line arguments for Mirth client.
      */
     public CommandLineOptions(String[] args) {
+        if (args == null) {
+            args = new String[0];
+        }
+
         String server = "https://localhost:8443";
         String version = "";
         String username = "";
         String password = "";
         String protocols = "";
         String cipherSuites = "";
+        String pinnedClientTrust = "";
 
-        if (args == null) {
-            args = new String[0];
-        }
+        Deque<String> remaining = new ArrayDeque<String>(Arrays.asList(args));
+        int idx = 0;
+        while (true) {
+            String arg = remaining.pollFirst();
+            if (arg == null) {
+                break;
+            }
 
-        if (args.length > 0) {
-            server = args[0];
-        }
-        if (args.length > 1) {
-            version = args[1];
-        }
-        if (args.length > 2) {
-            if (StringUtils.equalsIgnoreCase(args[2], "-ssl")) {
-                // <server> <version> -ssl [<protocols> [<ciphersuites> [<username> [<password>]]]]
-                if (args.length > 3) {
-                    protocols = args[3];
-                }
-                if (args.length > 4) {
-                    cipherSuites = args[4];
-                }
-                if (args.length > 5) {
-                    username = args[5];
-                }
-                if (args.length > 6) {
-                    password = args[6];
-                }
+            if (StringUtils.equalsIgnoreCase(arg, "-ssl")) {
+                protocols = StringUtils.defaultString(remaining.pollFirst());
+                cipherSuites = StringUtils.defaultString(remaining.pollFirst());
+            } else if (StringUtils.equalsIgnoreCase(arg, "-trust")) {
+                pinnedClientTrust = StringUtils.defaultString(remaining.pollFirst());
             } else {
-                // <server> <version> <username> [<password> [-ssl [<protocols> [<ciphersuites>]]]]
-                username = args[2];
-                if (args.length > 3) {
-                    password = args[3];
+                switch (idx) {
+                    case 0 -> server = arg;
+                    case 1 -> version = arg;
+                    case 2 -> username = arg;
+                    case 3 -> password = arg;
+                    default -> {} // Explicitly ignore extra arguments
                 }
-                if (args.length > 4 && StringUtils.equalsIgnoreCase(args[4], "-ssl")) {
-                    if (args.length > 5) {
-                        protocols = args[5];
-                    }
-                    if (args.length > 6) {
-                        cipherSuites = args[6];
-                    }
-                }
+                idx++;
             }
         }
 
@@ -73,8 +66,9 @@ public class CommandLineOptions {
         this.version = version;
         this.username = username;
         this.password = password;
-        this.protocols = protocols;
-        this.cipherSuites = cipherSuites;
+        this.protocols = StringUtils.defaultString(protocols);
+        this.cipherSuites = StringUtils.defaultString(cipherSuites);
+        this.pinnedClientTrust = StringUtils.defaultString(pinnedClientTrust);
     }
 
     public String getServer() {
@@ -99,5 +93,9 @@ public class CommandLineOptions {
 
     public String getCipherSuites() {
         return cipherSuites;
+    }
+
+    public String getPinnedClientTrust() {
+        return pinnedClientTrust;
     }
 }

--- a/client/src/com/mirth/connect/client/ui/LoginPanel.java
+++ b/client/src/com/mirth/connect/client/ui/LoginPanel.java
@@ -423,7 +423,7 @@ public class LoginPanel extends javax.swing.JFrame {
 
                 try {
                     String server = serverName.getText();
-                    client = new Client(server, PlatformUI.HTTPS_PROTOCOLS, PlatformUI.HTTPS_CIPHER_SUITES);
+                    client = new Client(server, PlatformUI.HTTPS_PROTOCOLS, PlatformUI.HTTPS_CIPHER_SUITES, PlatformUI.PINNED_CLIENT_TRUST);
                     PlatformUI.SERVER_URL = server;
 
                     // Attempt to login

--- a/client/src/com/mirth/connect/client/ui/Mirth.java
+++ b/client/src/com/mirth/connect/client/ui/Mirth.java
@@ -261,6 +261,7 @@ public class Mirth {
         if (StringUtils.isNotBlank(opts.getCipherSuites())) {
             PlatformUI.HTTPS_CIPHER_SUITES = StringUtils.split(opts.getCipherSuites(), ',');
         }
+        PlatformUI.PINNED_CLIENT_TRUST = opts.getPinnedClientTrust();
         PlatformUI.SERVER_URL = opts.getServer();
         PlatformUI.CLIENT_VERSION = opts.getVersion();
 

--- a/client/src/com/mirth/connect/client/ui/PlatformUI.java
+++ b/client/src/com/mirth/connect/client/ui/PlatformUI.java
@@ -33,6 +33,7 @@ public class PlatformUI {
     public static String SERVER_DATABASE;
     public static String USER_NAME;
     public static String CLIENT_VERSION;
+    public static String PINNED_CLIENT_TRUST;
     public static String SERVER_VERSION;
     public static String BUILD_DATE;
     public static Color DEFAULT_BACKGROUND_COLOR = ServerSettings.DEFAULT_COLOR;

--- a/client/test/com/mirth/connect/client/ui/CommandLineOptionsTest.java
+++ b/client/test/com/mirth/connect/client/ui/CommandLineOptionsTest.java
@@ -20,6 +20,7 @@ public class CommandLineOptionsTest {
         assertEquals("secret", opts.getPassword());
         assertEquals("TLSv1.2,TLSv1.3", opts.getProtocols());
         assertEquals("TLS_RSA_WITH_AES_128_GCM_SHA256", opts.getCipherSuites());
+        assertEquals("", opts.getPinnedClientTrust());
     }
 
     @Test
@@ -33,6 +34,49 @@ public class CommandLineOptionsTest {
         assertEquals("pw", opts.getPassword());
         assertEquals("TLSv1.2", opts.getProtocols());
         assertEquals("CIPHER", opts.getCipherSuites());
+        assertEquals("", opts.getPinnedClientTrust());
+    }
+
+    @Test
+    public void testParseSslFormWithPinnedClientTrust() {
+        String[] args = new String[] { "https://example:8443", "1.0", "-ssl", "TLSv1.2,TLSv1.3", "TLS_RSA_WITH_AES_128_GCM_SHA256", "alice", "secret", "-trust", "abcdef1234,5489349" };
+        CommandLineOptions opts = new CommandLineOptions(args);
+
+        assertEquals("https://example:8443", opts.getServer());
+        assertEquals("1.0", opts.getVersion());
+        assertEquals("alice", opts.getUsername());
+        assertEquals("secret", opts.getPassword());
+        assertEquals("TLSv1.2,TLSv1.3", opts.getProtocols());
+        assertEquals("TLS_RSA_WITH_AES_128_GCM_SHA256", opts.getCipherSuites());
+        assertEquals("abcdef1234,5489349", opts.getPinnedClientTrust());
+    }
+
+    @Test
+    public void testParseUsernameFormWithPinnedClientTrust() {
+        String[] args = new String[] { "https://example:8443", "1.0", "bob", "pw", "-trust", "localhost,a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3" };
+        CommandLineOptions opts = new CommandLineOptions(args);
+
+        assertEquals("https://example:8443", opts.getServer());
+        assertEquals("1.0", opts.getVersion());
+        assertEquals("bob", opts.getUsername());
+        assertEquals("pw", opts.getPassword());
+        assertEquals("", opts.getProtocols());
+        assertEquals("", opts.getCipherSuites());
+        assertEquals("localhost,a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3", opts.getPinnedClientTrust());
+    }
+
+    @Test
+    public void testParsePinnedClientTrustAfterredentials() {
+        String[] args = new String[] { "https://example:8443", "1.0", "bob", "pw", "-trust", "localhost,a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3" };
+        CommandLineOptions opts = new CommandLineOptions(args);
+
+        assertEquals("https://example:8443", opts.getServer());
+        assertEquals("1.0", opts.getVersion());
+        assertEquals("bob", opts.getUsername());
+        assertEquals("pw", opts.getPassword());
+        assertEquals("", opts.getProtocols());
+        assertEquals("", opts.getCipherSuites());
+        assertEquals("localhost,a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3a3", opts.getPinnedClientTrust());
     }
 
     @Test
@@ -45,6 +89,7 @@ public class CommandLineOptionsTest {
         assertEquals("", opts.getPassword());
         assertEquals("", opts.getProtocols());
         assertEquals("", opts.getCipherSuites());
+        assertEquals("", opts.getPinnedClientTrust());
     }
 
     @Test
@@ -58,5 +103,6 @@ public class CommandLineOptionsTest {
         assertEquals("", opts.getPassword());
         assertEquals("", opts.getProtocols());
         assertEquals("", opts.getCipherSuites());
+        assertEquals("", opts.getPinnedClientTrust());
     }
 }

--- a/server/conf/mirth.properties
+++ b/server/conf/mirth.properties
@@ -63,6 +63,19 @@ server.includecustomlib = false
 
 # administrator
 administrator.maxheapsize = 512m
+# Controls how the client should validate the server's SSL certificate.
+# Comma separated list of options:
+# - pki
+#   Trust CA's and peer trust based on the client JVM config.  Requires
+#   the server hostname to match the certificate CN or SAN.  This is the
+#   "normal" trust required by most SSL clients.
+# - webserver
+#   Trust this server's certificate specifically.  Do not validate hostname.
+# - <thumbprint>
+#   Trust the specified SHA-256 certificate thumbprint.  Do not validate hostname.
+# - insecure_trust_all_certs
+#   Trust all certificates without validation. (not recommended)
+administrator.pinnedclienttrust = pki,webserver
 
 # properties file that will store the configuration map and be loaded during server startup
 configurationmap.path = ${dir.appdata}/configuration.properties

--- a/server/src/com/mirth/connect/client/core/CertificateThumbprintMatcher.java
+++ b/server/src/com/mirth/connect/client/core/CertificateThumbprintMatcher.java
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Set;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** A collection of trusted certificate thumbprints. */
+final class CertificateThumbprintMatcher {
+
+    private final Set<String> pinnedThumbprints;
+
+    CertificateThumbprintMatcher(Set<String> pinnedThumbprints) {
+        this.pinnedThumbprints = pinnedThumbprints;
+    }
+
+    boolean matches(SSLSession session) {
+        try {
+            return matches(session.getPeerCertificates());
+        } catch (SSLPeerUnverifiedException e) {
+            return false;
+        }
+    }
+
+    boolean matches(Certificate[] certificates) {
+        if (pinnedThumbprints.isEmpty() || certificates == null) {
+            return false;
+        }
+
+        for (Certificate certificate : certificates) {
+            if (certificate instanceof X509Certificate) {
+                try {
+                    if (pinnedThumbprints.contains(getThumbprint((X509Certificate) certificate))) {
+                        return true;
+                    }
+                } catch (CertificateException e) {
+                    continue;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static String normalize(String thumbprint) {
+        return StringUtils.lowerCase(StringUtils.deleteWhitespace(StringUtils.trimToEmpty(thumbprint)), Locale.ROOT);
+    }
+
+    private String getThumbprint(X509Certificate certificate) throws CertificateException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(certificate.getEncoded()));
+        } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+            throw new CertificateException("Unable to calculate certificate thumbprint.", e);
+        }
+    }
+}

--- a/server/src/com/mirth/connect/client/core/Client.java
+++ b/server/src/com/mirth/connect/client/core/Client.java
@@ -151,30 +151,43 @@ public class Client implements UserServletInterface, ConfigurationServletInterfa
      */
     public Client(String address) throws URISyntaxException {
         // Default timeout is infinite.
-        this(address, 0, MirthSSLUtil.DEFAULT_HTTPS_CLIENT_PROTOCOLS, MirthSSLUtil.DEFAULT_HTTPS_CIPHER_SUITES, null);
+        this(address, 0, MirthSSLUtil.DEFAULT_HTTPS_CLIENT_PROTOCOLS, MirthSSLUtil.DEFAULT_HTTPS_CIPHER_SUITES, null, null);
     }
 
     public Client(String address, String[] httpsProtocols, String[] httpsCipherSuites) throws URISyntaxException {
         // Default timeout is infinite.
-        this(address, 0, httpsProtocols, httpsCipherSuites, null);
+        this(address, httpsProtocols, httpsCipherSuites, (String) null);
+    }
+
+    public Client(String address, String[] httpsProtocols, String[] httpsCipherSuites, String pinnedClientTrust) throws URISyntaxException {
+        // Default timeout is infinite.
+        this(address, 0, httpsProtocols, httpsCipherSuites, pinnedClientTrust, null);
     }
 
     public Client(String address, String[] httpsProtocols, String[] httpsCipherSuites, String[] apiProviderClasses) throws URISyntaxException {
         // Default timeout is infinite.
-        this(address, 0, httpsProtocols, httpsCipherSuites, apiProviderClasses);
+        this(address, 0, httpsProtocols, httpsCipherSuites, null, apiProviderClasses);
     }
 
     public Client(String address, int timeout, String[] httpsProtocols, String[] httpsCipherSuites) throws URISyntaxException {
-        this(address, timeout, httpsProtocols, httpsCipherSuites, null);
+        this(address, timeout, httpsProtocols, httpsCipherSuites, null, null);
     }
 
     public Client(String address, int timeout, String[] httpsProtocols, String[] httpsCipherSuites, String[] apiProviderClasses) throws URISyntaxException {
+        this(address, timeout, httpsProtocols, httpsCipherSuites, null, apiProviderClasses);
+    }
+
+    public Client(String address, int timeout, String[] httpsProtocols, String[] httpsCipherSuites, String pinnedClientTrust) throws URISyntaxException {
+        this(address, timeout, httpsProtocols, httpsCipherSuites, pinnedClientTrust, null);
+    }
+
+    public Client(String address, int timeout, String[] httpsProtocols, String[] httpsCipherSuites, String pinnedClientTrust, String[] apiProviderClasses) throws URISyntaxException {
         if (!address.endsWith("/")) {
             address += "/";
         }
         URI addressURI = new URI(address);
 
-        serverConnection = new ServerConnection(timeout, httpsProtocols, httpsCipherSuites, StringUtils.equalsIgnoreCase(addressURI.getScheme(), "http"));
+        serverConnection = new ServerConnection(timeout, httpsProtocols, httpsCipherSuites, pinnedClientTrust, addressURI.getHost(), StringUtils.equalsIgnoreCase(addressURI.getScheme(), "http"));
 
         ClientConfig config = new ClientConfig().connectorProvider(new ConnectorProvider() {
             @Override

--- a/server/src/com/mirth/connect/client/core/CompositeHostnameVerifier.java
+++ b/server/src/com/mirth/connect/client/core/CompositeHostnameVerifier.java
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+/** A composite hostname verifier that delegates to multiple implementations. */
+public class CompositeHostnameVerifier implements HostnameVerifier {
+
+    private final List<HostnameVerifier> hostnameVerifiers;
+
+    public CompositeHostnameVerifier(List<HostnameVerifier> hostnameVerifiers) {
+        this.hostnameVerifiers = new ArrayList<HostnameVerifier>(hostnameVerifiers);
+    }
+
+    @Override
+    public boolean verify(String host, SSLSession session) {
+        for (HostnameVerifier hostnameVerifier : hostnameVerifiers) {
+            if (hostnameVerifier.verify(host, session)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/server/src/com/mirth/connect/client/core/CompositeTrustStrategy.java
+++ b/server/src/com/mirth/connect/client/core/CompositeTrustStrategy.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.conn.ssl.TrustStrategy;
+
+/** A composite trust strategy that delegates to multiple implementations. */
+public class CompositeTrustStrategy implements TrustStrategy {
+
+    private final List<TrustStrategy> trustStrategies;
+
+    public CompositeTrustStrategy(List<TrustStrategy> trustStrategies) {
+        this.trustStrategies = new ArrayList<TrustStrategy>(trustStrategies);
+    }
+
+    @Override
+    public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        for (TrustStrategy trustStrategy : trustStrategies) {
+            if (trustStrategy.isTrusted(chain, authType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/server/src/com/mirth/connect/client/core/LocalhostTrustStrategy.java
+++ b/server/src/com/mirth/connect/client/core/LocalhostTrustStrategy.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+import org.apache.http.conn.ssl.TrustStrategy;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** A "trust all" strategy for localhost hosts. */
+public class LocalhostTrustStrategy implements TrustStrategy, HostnameVerifier {
+
+    private final boolean localhostConnection;
+
+    public LocalhostTrustStrategy(String serverHost) {
+        localhostConnection = isLocalhost(serverHost);
+    }
+
+    @Override
+    public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        return localhostConnection;
+    }
+
+    @Override
+    public boolean verify(String host, SSLSession session) {
+        return localhostConnection && isLocalhost(host);
+    }
+
+    private static boolean isLocalhost(String host) {
+        return StringUtils.equalsAnyIgnoreCase(host, "localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1");
+    }
+}

--- a/server/src/com/mirth/connect/client/core/PinnedCertificateTrustStrategy.java
+++ b/server/src/com/mirth/connect/client/core/PinnedCertificateTrustStrategy.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+import org.apache.http.conn.ssl.TrustStrategy;
+
+/** A trust strategy that validates certificates based on pinned thumbprints, ignoring hostname verification. */
+public class PinnedCertificateTrustStrategy implements TrustStrategy, HostnameVerifier {
+
+    private final CertificateThumbprintMatcher certificateThumbprintMatcher;
+
+    public PinnedCertificateTrustStrategy(Set<String> pinnedThumbprints) {
+        certificateThumbprintMatcher = new CertificateThumbprintMatcher(pinnedThumbprints);
+    }
+
+    @Override
+    public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        if (chain == null) {
+            return false;
+        }
+
+        return certificateThumbprintMatcher.matches(chain);
+    }
+
+    @Override
+    public boolean verify(String host, SSLSession session) {
+        return certificateThumbprintMatcher.matches(session);
+    }
+}

--- a/server/src/com/mirth/connect/client/core/PinnedClientTrustConfig.java
+++ b/server/src/com/mirth/connect/client/core/PinnedClientTrustConfig.java
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** Parses trust list for the client */
+public class PinnedClientTrustConfig {
+
+    private static final String DEFAULT_VALUE = "pki,localhost";
+    private static final String LOCALHOST_VALUE = "localhost";
+    private static final String INSECURE_TRUST_ALL_CERTS_VALUE = "insecure_trust_all_certs";
+    private static final String PKI_VALUE = "pki";
+
+    private static final Pattern SHA_256_PATTERN = Pattern.compile("[0-9a-f]{64}");
+
+    private final boolean pkiAllowed;
+    private final boolean localhostAllowed;
+    private final boolean trustAllCertificates;
+    private final Set<String> pinnedThumbprints;
+
+    private PinnedClientTrustConfig(boolean pkiAllowed, boolean localhostAllowed, boolean trustAllCertificates, Set<String> pinnedThumbprints) {
+        this.pkiAllowed = pkiAllowed;
+        this.localhostAllowed = localhostAllowed;
+        this.trustAllCertificates = trustAllCertificates;
+        this.pinnedThumbprints = pinnedThumbprints;
+    }
+
+    /* Create from the argument string or default if null/blank. */
+    public static PinnedClientTrustConfig parse(String pinnedClientTrust) {
+        String trimmedValue = StringUtils.defaultIfBlank(pinnedClientTrust, DEFAULT_VALUE);
+
+        String[] tokens = StringUtils.split(trimmedValue, ',');
+        if (tokens == null || tokens.length == 0) {
+            throw new IllegalArgumentException("PinnedClientTrust is invalid: " + pinnedClientTrust);
+        }
+
+        boolean pkiAllowed = false;
+        boolean localhostAllowed = false;
+        boolean trustAllCertificates = false;
+
+        Set<String> pinnedThumbprints = new HashSet<String>();
+        for (String token : tokens) {
+            String cleanedToken = StringUtils.trimToEmpty(token);
+            if (StringUtils.isBlank(cleanedToken)) {
+                continue;
+            }
+
+            if (StringUtils.equalsIgnoreCase(cleanedToken, PKI_VALUE)) {
+                pkiAllowed = true;
+            } else if (StringUtils.equalsIgnoreCase(cleanedToken, LOCALHOST_VALUE)) {
+                localhostAllowed = true;
+            } else if (StringUtils.equalsIgnoreCase(cleanedToken, INSECURE_TRUST_ALL_CERTS_VALUE)) {
+                trustAllCertificates = true;
+            } else {
+                String thumbprint = CertificateThumbprintMatcher.normalize(cleanedToken);
+                if (!SHA_256_PATTERN.matcher(thumbprint).matches()) {
+                    throw new IllegalArgumentException("PinnedClientTrust contains an invalid token: " + token);
+                }
+                pinnedThumbprints.add(thumbprint);
+            }
+        }
+
+        if (!pkiAllowed && !localhostAllowed && !trustAllCertificates && pinnedThumbprints.isEmpty()) {
+            throw new IllegalArgumentException("PinnedClientTrust must enable at least one trust mode.");
+        }
+
+        return new PinnedClientTrustConfig(pkiAllowed, localhostAllowed, trustAllCertificates, Collections.unmodifiableSet(pinnedThumbprints));
+    }
+
+    /** Returns the set of trusted certificate thumbprints. */
+    public Set<String> getPinnedThumbprints() {
+        return pinnedThumbprints;
+    }
+
+    /** Determines whether the public-key infrastructure (PKI) is trusted. */
+    public boolean isPkiTrusted() {
+        return pkiAllowed;
+    }
+
+    /** Determines whether localhost should be trusted without validation. */
+    public boolean isLocalhostTrusted() {
+        return localhostAllowed;
+    }
+
+    /** Determines whether all certificates should be trusted without validation. */
+    public boolean isTrustAllCertificates() {
+        return trustAllCertificates;
+    }
+}

--- a/server/src/com/mirth/connect/client/core/PinnedClientTrustSslContextFactory.java
+++ b/server/src/com/mirth/connect/client/core/PinnedClientTrustSslContextFactory.java
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.ssl.SSLContexts;
+
+/** Entrypoint for interpreting the trust configuration for the client */
+public class PinnedClientTrustSslContextFactory {
+
+    /** Creates an SSL context based on the pinned client trust configuration. */
+    public SSLContext createSslContext(PinnedClientTrustConfig pinnedClientTrustConfig, String serverHost) {
+        try {
+            if (pinnedClientTrustConfig.isTrustAllCertificates()) {
+                return SSLContexts.custom().loadTrustMaterial(null, new TrustAllStrategy()).build();
+            }
+
+            KeyStore trustStore = null;
+            if (!pinnedClientTrustConfig.isPkiTrusted()) {
+                trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+                trustStore.load(null, null);
+            }
+
+            var trustStrategy = createTrustStrategy(pinnedClientTrustConfig, serverHost);
+            return SSLContexts.custom().loadTrustMaterial(trustStore, trustStrategy).build();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to build SSL context.", e);
+        }
+    }
+
+    /** Creates a hostname verifier based on the pinned client trust configuration. */
+    public HostnameVerifier createHostnameVerifier(PinnedClientTrustConfig pinnedClientTrustConfig, String serverHost) {
+        if (pinnedClientTrustConfig.isTrustAllCertificates()) {
+            return NoopHostnameVerifier.INSTANCE;
+        }
+
+        List<HostnameVerifier> hostnameVerifiers = new ArrayList<HostnameVerifier>();
+        if (pinnedClientTrustConfig.isLocalhostTrusted()) {
+            hostnameVerifiers.add(new LocalhostTrustStrategy(serverHost));
+        }
+        var pinned = pinnedClientTrustConfig.getPinnedThumbprints();
+        if (!pinned.isEmpty()) {
+            hostnameVerifiers.add(new PinnedCertificateTrustStrategy(pinned));
+        }
+        if (pinnedClientTrustConfig.isPkiTrusted()) {
+            hostnameVerifiers.add(new DefaultHostnameVerifier());
+        }
+
+        return new CompositeHostnameVerifier(hostnameVerifiers);
+    }
+
+    private TrustStrategy createTrustStrategy(PinnedClientTrustConfig pinnedClientTrustConfig, String serverHost) {
+        List<TrustStrategy> trustStrategies = new ArrayList<TrustStrategy>();
+        if (pinnedClientTrustConfig.isLocalhostTrusted()) {
+            trustStrategies.add(new LocalhostTrustStrategy(serverHost));
+        }
+        var pinned = pinnedClientTrustConfig.getPinnedThumbprints();
+        if (!pinned.isEmpty()) {
+            trustStrategies.add(new PinnedCertificateTrustStrategy(pinned));
+        }
+
+        return new CompositeTrustStrategy(trustStrategies);
+    }
+}

--- a/server/src/com/mirth/connect/client/core/ServerConnection.java
+++ b/server/src/com/mirth/connect/client/core/ServerConnection.java
@@ -58,9 +58,7 @@ import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ConnectionKeepAliveStrategy;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCookieStore;
@@ -70,7 +68,6 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
-import org.apache.http.ssl.SSLContexts;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.glassfish.jersey.client.ClientRequest;
@@ -110,22 +107,32 @@ public class ServerConnection implements Connector {
     private ExecutorService abortExecutor = Executors.newSingleThreadExecutor();
     private IdleConnectionMonitor idleConnectionMonitor;
     private ConnectionKeepAliveStrategy keepAliveStrategy;
+    private final PinnedClientTrustSslContextFactory pinnedClientTrustSslContextFactory = new PinnedClientTrustSslContextFactory();
 
+    /**
+     * @deprecated Use {@link #ServerConnection(int, String[], String[], String, String, boolean)} so trust behavior can be configured explicitly.
+     */
+    @Deprecated
     public ServerConnection(int timeout, String[] httpsProtocols, String[] httpsCipherSuites) {
-        this(timeout, httpsProtocols, httpsCipherSuites, false);
+        this(timeout, httpsProtocols, httpsCipherSuites, null, null, false);
     }
 
+    /**
+     * @deprecated Use {@link #ServerConnection(int, String[], String[], String, String, boolean)} so trust behavior can be configured explicitly.
+     */
+    @Deprecated
     public ServerConnection(int timeout, String[] httpsProtocols, String[] httpsCipherSuites, boolean allowHTTP) {
-        SSLContext sslContext = null;
-        try {
-            sslContext = SSLContexts.custom().loadTrustMaterial(null, new TrustSelfSignedStrategy()).build();
-        } catch (Exception e) {
-            logger.error("Unable to build SSL context.", e);
-        }
+        this(timeout, httpsProtocols, httpsCipherSuites, null, null, allowHTTP);
+    }
+
+    public ServerConnection(int timeout, String[] httpsProtocols, String[] httpsCipherSuites, String pinnedClientTrust, String serverHost, boolean allowHTTP) {
+        PinnedClientTrustConfig pinnedClientTrustConfig = PinnedClientTrustConfig.parse(pinnedClientTrust);
+        SSLContext sslContext = pinnedClientTrustSslContextFactory.createSslContext(pinnedClientTrustConfig, serverHost);
 
         String[] enabledProtocols = MirthSSLUtil.getEnabledHttpsProtocols(httpsProtocols);
         String[] enabledCipherSuites = MirthSSLUtil.getEnabledHttpsCipherSuites(httpsCipherSuites);
-        SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslContext, enabledProtocols, enabledCipherSuites, NoopHostnameVerifier.INSTANCE);
+        SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslContext, enabledProtocols, enabledCipherSuites,
+            pinnedClientTrustSslContextFactory.createHostnameVerifier(pinnedClientTrustConfig, serverHost));
         RegistryBuilder<ConnectionSocketFactory> builder = RegistryBuilder.<ConnectionSocketFactory> create().register("https", sslConnectionSocketFactory);
         if (allowHTTP) {
             builder.register("http", PlainConnectionSocketFactory.getSocketFactory());

--- a/server/src/com/mirth/connect/server/controllers/ConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/ConfigurationController.java
@@ -210,6 +210,11 @@ public abstract class ConfigurationController extends Controller {
     public abstract String generateGuid();
 
     /**
+     * Returns the SHA-256 thumbprint for the server certificate in the configured keystore.
+     */
+    public abstract String getServerCertificateThumbprint() throws Exception;
+
+    /**
      * Returns the database driver list used for the Database Reader/Writer connectors.
      * 
      * @return a list of database driver metadata

--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.MessageDigest;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -196,6 +198,7 @@ public class DefaultConfigurationController extends ConfigurationController {
     private static final String XSTREAM_ALLOW_TYPE_HIERARCHIES = "xstream.allowtypehierarchies";
 
     private static final String DEFAULT_STOREPASS = "81uWxplDtB";
+    private static final String SERVER_CERTIFICATE_ALIAS = "mirthconnect";
 
     // singleton pattern
     private static ConfigurationController instance = null;
@@ -1511,15 +1514,29 @@ public class DefaultConfigurationController extends ConfigurationController {
         }
     }
 
+    @Override
+    public String getServerCertificateThumbprint() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(mirthConfig.getString("keystore.type", "JCEKS"));
+
+        try (FileInputStream keyStoreInputStream = new FileInputStream(new File(mirthConfig.getString("keystore.path")))) {
+            keyStore.load(keyStoreInputStream, mirthConfig.getString("keystore.storepass").toCharArray());
+        }
+
+        Certificate certificate = keyStore.getCertificate(SERVER_CERTIFICATE_ALIAS);
+        if (certificate == null) {
+            throw new IllegalStateException("Certificate alias not found in keystore: " + SERVER_CERTIFICATE_ALIAS);
+        }
+
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded()));
+    }
+
     /**
      * Checks for an existing certificate to use for secure communication between the server and
      * client. If no certficate exists, this will generate a new one.
      * 
      */
     private void generateDefaultCertificate(Provider provider, KeyStore keyStore, char[] keyPassword) throws Exception {
-        final String certificateAlias = "mirthconnect";
-
-        if (!keyStore.containsAlias(certificateAlias)) {
+        if (!keyStore.containsAlias(SERVER_CERTIFICATE_ALIAS)) {
             // Common CA and SSL cert attributes
             Date startDate = new Date(); // time from which certificate is valid
             Date expiryDate = DateUtils.addYears(startDate, 50); // time after which certificate is not valid
@@ -1553,7 +1570,7 @@ public class DefaultConfigurationController extends ConfigurationController {
             logger.debug("generated new certificate with serial number: " + ((X509Certificate) sslCert).getSerialNumber());
 
             // add the generated SSL cert to the keystore using the key password
-            keyStore.setKeyEntry(certificateAlias, sslKeyPair.getPrivate(), keyPassword, new Certificate[] {
+            keyStore.setKeyEntry(SERVER_CERTIFICATE_ALIAS, sslKeyPair.getPrivate(), keyPassword, new Certificate[] {
                     sslCert });
         } else {
             logger.debug("found certificate in keystore");

--- a/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
+++ b/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
@@ -51,6 +51,7 @@ import com.mirth.connect.server.controllers.ConfigurationController;
 import com.mirth.connect.server.controllers.ControllerFactory;
 import com.mirth.connect.server.controllers.ExtensionController;
 import com.mirth.connect.server.tools.ClassPathResource;
+import com.mirth.connect.server.util.PinnedClientTrustResolver;
 import com.mirth.connect.server.util.ResourceUtil;
 import com.mirth.connect.util.MirthSSLUtil;
 
@@ -58,6 +59,7 @@ public class WebStartServlet extends HttpServlet {
     private Logger logger = LogManager.getLogger(this.getClass());
     private ConfigurationController configurationController = ControllerFactory.getFactory().createConfigurationController();
     private ExtensionController extensionController = ControllerFactory.getFactory().createExtensionController();
+    private final PinnedClientTrustResolver pinnedClientTrustResolver = new PinnedClientTrustResolver();
 
     /*
      * Override last modified time to always be modified so it updates changes to JNLP.
@@ -293,6 +295,17 @@ public class WebStartServlet extends HttpServlet {
             Element cipherSuitesArgumentElement = document.createElement("argument");
             cipherSuitesArgumentElement.setTextContent(StringUtils.join(cipherSuites, ','));
             applicationDescElement.appendChild(cipherSuitesArgumentElement);
+        }
+
+        String pinnedClientTrust = pinnedClientTrustResolver.resolve(mirthProperties, configurationController::getServerCertificateThumbprint);
+        if (StringUtils.isNotBlank(pinnedClientTrust)) {
+            Element pinnedClientTrustArgumentElement = document.createElement("argument");
+            pinnedClientTrustArgumentElement.setTextContent("-trust");
+            applicationDescElement.appendChild(pinnedClientTrustArgumentElement);
+
+            Element pinnedClientTrustValueArgumentElement = document.createElement("argument");
+            pinnedClientTrustValueArgumentElement.setTextContent(pinnedClientTrust);
+            applicationDescElement.appendChild(pinnedClientTrustValueArgumentElement);
         }
 
         return document;

--- a/server/src/com/mirth/connect/server/util/PinnedClientTrustResolver.java
+++ b/server/src/com/mirth/connect/server/util/PinnedClientTrustResolver.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.server.util;
+
+import java.util.concurrent.Callable;
+import java.util.StringJoiner;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.lang3.StringUtils;
+
+/** Utility class for interpreting the "administrator.pinnedclienttrust" property */
+public class PinnedClientTrustResolver {
+    private static final String DEFAULT_VALUE = "pki,webserver";
+    private static final String PROPERTY_NAME = "administrator.pinnedclienttrust";
+
+    public String resolve(PropertiesConfiguration mirthProperties, Callable<String> getServerCert) throws Exception {
+        String pinnedClientTrust = StringUtils.defaultIfBlank(
+            StringUtils.trimToNull(mirthProperties.getString(PROPERTY_NAME)), DEFAULT_VALUE);
+            
+        var joiner = new StringJoiner(",");
+        for (String token : pinnedClientTrust.split(",")) {
+            String cleaned = token.strip();
+            if (cleaned.isEmpty()) continue;
+
+            if (cleaned.equalsIgnoreCase("webserver")) {
+                joiner.add(getServerCert.call());
+            } else {
+                joiner.add(cleaned);
+            }
+        }
+        return joiner.toString();
+    }
+}

--- a/server/test/com/mirth/connect/client/core/PinnedClientTrustConfigTest.java
+++ b/server/test/com/mirth/connect/client/core/PinnedClientTrustConfigTest.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PinnedClientTrustConfigTest {
+
+    private static final String THUMBPRINT = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    @Test
+    public void testParseDefaultValue() {
+        PinnedClientTrustConfig config = PinnedClientTrustConfig.parse(null);
+
+        assertTrue(config.isPkiTrusted());
+        assertTrue(config.isLocalhostTrusted());
+        assertFalse(config.isTrustAllCertificates());
+        assertTrue(config.getPinnedThumbprints().isEmpty());
+    }
+
+    @Test
+    public void testParseMixedValues() {
+        PinnedClientTrustConfig config = PinnedClientTrustConfig.parse("pki, localhost, " + THUMBPRINT.toUpperCase());
+
+        assertTrue(config.isPkiTrusted());
+        assertTrue(config.isLocalhostTrusted());
+        assertFalse(config.isTrustAllCertificates());
+        assertTrue(config.getPinnedThumbprints().contains(THUMBPRINT));
+    }
+
+    @Test
+    public void testParseTrustAll() {
+        PinnedClientTrustConfig config = PinnedClientTrustConfig.parse("insecure_trust_all_certs");
+
+        assertFalse(config.isPkiTrusted());
+        assertFalse(config.isLocalhostTrusted());
+        assertTrue(config.isTrustAllCertificates());
+    }
+
+    @Test
+    public void testParseThumbprintDisablesPkiUnlessExplicitlyEnabled() {
+        PinnedClientTrustConfig config = PinnedClientTrustConfig.parse(THUMBPRINT);
+
+        assertFalse(config.isPkiTrusted());
+        assertFalse(config.getPinnedThumbprints().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRejectInvalidToken() {
+        PinnedClientTrustConfig.parse("nopki");
+    }
+
+    @Test
+    public void testRecognizeLocalhostHosts() {
+        LocalhostTrustStrategy strategy = new LocalhostTrustStrategy("localhost");
+
+        assertTrue(strategy.verify("localhost", null));
+        assertTrue(strategy.verify("127.0.0.1", null));
+        assertTrue(strategy.verify("::1", null));
+        assertFalse(strategy.verify("example.com", null));
+    }
+}

--- a/server/test/com/mirth/connect/client/core/PinnedClientTrustSslContextFactoryTest.java
+++ b/server/test/com/mirth/connect/client/core/PinnedClientTrustSslContextFactoryTest.java
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.client.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+import org.junit.Test;
+
+public class PinnedClientTrustSslContextFactoryTest {
+
+    private static final byte[] CERT_BYTES = new byte[] { 97, 98, 99 };
+    private static final String THUMBPRINT = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    private final PinnedClientTrustSslContextFactory factory = new PinnedClientTrustSslContextFactory();
+
+    @Test
+    public void testHostnameVerifierAllowsPinnedCertificateWithoutHostnameMatch() throws Exception {
+        HostnameVerifier verifier = factory.createHostnameVerifier(PinnedClientTrustConfig.parse(THUMBPRINT), "example.com");
+
+        assertTrue(verifier.verify("different-host", mockPinnedSession()));
+    }
+
+    @Test
+    public void testHostnameVerifierAllowsLocalhostConnections() {
+        HostnameVerifier verifier = factory.createHostnameVerifier(PinnedClientTrustConfig.parse("localhost"), "localhost");
+
+        assertTrue(verifier.verify("localhost", mock(SSLSession.class)));
+    }
+
+    @Test
+    public void testHostnameVerifierRejectsNonLocalhostWhenOnlyLocalhostIsAllowed() {
+        HostnameVerifier verifier = factory.createHostnameVerifier(PinnedClientTrustConfig.parse("localhost"), "example.com");
+
+        assertFalse(verifier.verify("example.com", mock(SSLSession.class)));
+    }
+
+    @Test
+    public void testHostnameVerifierAllowsTrustAll() {
+        HostnameVerifier verifier = factory.createHostnameVerifier(PinnedClientTrustConfig.parse("insecure_trust_all_certs"), "example.com");
+
+        assertTrue(verifier.verify("example.com", mock(SSLSession.class)));
+    }
+
+    @Test
+    public void testTrustStrategyAllowsPinnedCertificate() throws Exception {
+        PinnedCertificateTrustStrategy strategy = new PinnedCertificateTrustStrategy(PinnedClientTrustConfig.parse(THUMBPRINT).getPinnedThumbprints());
+
+        assertTrue(strategy.isTrusted(new X509Certificate[] { mockCertificate() }, "RSA"));
+    }
+
+    @Test
+    public void testTrustStrategyAllowsLocalhostConnectionWithoutCertificateChecks() throws Exception {
+        LocalhostTrustStrategy strategy = new LocalhostTrustStrategy("127.0.0.1");
+
+        assertTrue(strategy.isTrusted(null, "RSA"));
+    }
+
+    @Test
+    public void testTrustStrategyDefersWhenCertificateIsNotPinned() throws Exception {
+        PinnedCertificateTrustStrategy strategy = new PinnedCertificateTrustStrategy(PinnedClientTrustConfig.parse(THUMBPRINT).getPinnedThumbprints());
+
+        assertFalse(strategy.isTrusted(new X509Certificate[] { mockDifferentCertificate() }, "RSA"));
+    }
+
+    private SSLSession mockPinnedSession() throws Exception {
+        SSLSession session = mock(SSLSession.class);
+        Certificate certificate = mockCertificate();
+        when(session.getPeerCertificates()).thenReturn(new Certificate[] { certificate });
+        return session;
+    }
+
+    private X509Certificate mockCertificate() throws Exception {
+        X509Certificate certificate = mock(X509Certificate.class);
+        when(certificate.getEncoded()).thenReturn(CERT_BYTES);
+        return certificate;
+    }
+
+    private X509Certificate mockDifferentCertificate() throws Exception {
+        X509Certificate certificate = mock(X509Certificate.class);
+        when(certificate.getEncoded()).thenReturn(new byte[] { 100, 101, 102 });
+        return certificate;
+    }
+}


### PR DESCRIPTION
Addresses MITM vulnerability by adding `-trust {config}` option to client.  Adds `administrator.pinnedclienttrust` option to mirth.properties to control the option.

| Option | Description | Hostname Validation |
| :--- | :--- | :--- |
| `pki` | Trust CAs and peer trust based on client JVM config. Normal trust mode. | Required (matches CN or SAN) |
| `webserver` | Trust the auto-generated server's certificate. | Not Validated |
| `<thumbprint>` | Trust a specified SHA-256 certificate thumbprint. | Not Validated |
| `insecure_trust_all_certs` | Trust all certificates without validation (not recommended). | Not Validated |
| `localhost` | Trust all certificates for the hostname localhost | Not Validated |

If argument is not passed to the client (e.g.: for development without a launcher), `pki,localhost` is used.  If the option is not specified in mirth.properties or for new installs, `pki,webserver` is used.  Multiple options can be specified by separating with commas.

Typical scenarios:

- Localhost, docker, or direct network access with trusted or self signed certificate<br>✅ No edits needed, secure by default
- Reverse proxy with trusted certificate<br>✅ No edits needed, secure by default
- Reverse proxy with self signed certificate<br>⚠️ Edit needed to add the proxy's certificate or enable `insecure_trust_all_certs`