### PR TITLE
cache ResultSet metadata in getMetaDataMapByMessageId to reduce per-row metadata lookups

### DIFF
--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
@@ -2935,8 +2935,6 @@ public class JdbcDao implements DonkeyDao {
             statement = connection.prepareStatement(querySource.getQuery("getMetaDataMapByMessageId", values));
             resultSet = statement.executeQuery();
 
-            // Cache ResultSet metadata before the loop — the schema is the same for every row,
-            // so calling getMetaData()/getColumnType()/getColumnName() per row is wasteful.
             MetaDataColumnType[] columnTypes = null;
             String[] columnNames = null;
             int columnCount = 0;

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
@@ -2937,20 +2937,16 @@ public class JdbcDao implements DonkeyDao {
 
             MetaDataColumnType[] columnTypes = null;
             String[] columnNames = null;
-            int columnCount = 0;
+            ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+            int columnCount = resultSetMetaData.getColumnCount();
+            MetaDataColumnType[] columnTypes = new MetaDataColumnType[columnCount];
+            String[] columnNames = new String[columnCount];
+            for (int i = 0; i < columnCount; i++) {
+                columnTypes[i] = MetaDataColumnType.fromSqlType(resultSetMetaData.getColumnType(i + 1));
+                columnNames[i] = resultSetMetaData.getColumnName(i + 1).toUpperCase();
+            }
 
             while (resultSet.next()) {
-                if (columnTypes == null) {
-                    ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-                    columnCount = resultSetMetaData.getColumnCount();
-                    columnTypes = new MetaDataColumnType[columnCount];
-                    columnNames = new String[columnCount];
-                    for (int i = 0; i < columnCount; i++) {
-                        columnTypes[i] = MetaDataColumnType.fromSqlType(resultSetMetaData.getColumnType(i + 1));
-                        columnNames[i] = resultSetMetaData.getColumnName(i + 1).toUpperCase();
-                    }
-                }
-
                 Long messageId = resultSet.getLong("message_id");
                 Integer metaDataId = resultSet.getInt("metadata_id");
 

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
@@ -2935,7 +2935,24 @@ public class JdbcDao implements DonkeyDao {
             statement = connection.prepareStatement(querySource.getQuery("getMetaDataMapByMessageId", values));
             resultSet = statement.executeQuery();
 
+            // Cache ResultSet metadata before the loop — the schema is the same for every row,
+            // so calling getMetaData()/getColumnType()/getColumnName() per row is wasteful.
+            MetaDataColumnType[] columnTypes = null;
+            String[] columnNames = null;
+            int columnCount = 0;
+
             while (resultSet.next()) {
+                if (columnTypes == null) {
+                    ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+                    columnCount = resultSetMetaData.getColumnCount();
+                    columnTypes = new MetaDataColumnType[columnCount];
+                    columnNames = new String[columnCount];
+                    for (int i = 0; i < columnCount; i++) {
+                        columnTypes[i] = MetaDataColumnType.fromSqlType(resultSetMetaData.getColumnType(i + 1));
+                        columnNames[i] = resultSetMetaData.getColumnName(i + 1).toUpperCase();
+                    }
+                }
+
                 Long messageId = resultSet.getLong("message_id");
                 Integer metaDataId = resultSet.getInt("metadata_id");
 
@@ -2951,29 +2968,26 @@ public class JdbcDao implements DonkeyDao {
                     connectorMetaDataMap.put(metaDataId, metaDataMap);
                 }
 
-                ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-                int columnCount = resultSetMetaData.getColumnCount();
-
-                for (int i = 1; i <= columnCount; i++) {
-                    MetaDataColumnType metaDataColumnType = MetaDataColumnType.fromSqlType(resultSetMetaData.getColumnType(i));
+                for (int i = 0; i < columnCount; i++) {
                     Object value = null;
+                    int colIndex = i + 1;
 
-                    switch (metaDataColumnType) {//@formatter:off
+                    switch (columnTypes[i]) {//@formatter:off
                         case STRING:
-                            value = resultSet.getString(i);
+                            value = resultSet.getString(colIndex);
                             if (encryptor != null && StringUtils.startsWith((String) value, Encryptor.HEADER_INDICATOR)) {
                                 try {
                                     value = encryptor.decrypt((String) value);
                                 } catch (Exception e) {
-                                    logger.debug("Unable to decrypt custom metadata column " + resultSetMetaData.getColumnName(i).toUpperCase() + " for channel " + channelId + ", messsage " + messageId + "-" + metaDataId, e);
+                                    logger.debug("Unable to decrypt custom metadata column " + columnNames[i] + " for channel " + channelId + ", messsage " + messageId + "-" + metaDataId, e);
                                 }
                             }
                             break;
-                        case NUMBER: value = resultSet.getBigDecimal(i); break;
-                        case BOOLEAN: value = resultSet.getBoolean(i); break;
+                        case NUMBER: value = resultSet.getBigDecimal(colIndex); break;
+                        case BOOLEAN: value = resultSet.getBoolean(colIndex); break;
                         case TIMESTAMP:
-                            
-                            Timestamp timestamp = resultSet.getTimestamp(i);
+
+                            Timestamp timestamp = resultSet.getTimestamp(colIndex);
                             if (timestamp != null) {
                                 value = Calendar.getInstance();
                                 ((Calendar) value).setTimeInMillis(timestamp.getTime());
@@ -2983,7 +2997,7 @@ public class JdbcDao implements DonkeyDao {
                         default: throw new Exception("Unrecognized MetaDataColumnType");
                     } //@formatter:on
 
-                    metaDataMap.put(resultSetMetaData.getColumnName(i).toUpperCase(), value);
+                    metaDataMap.put(columnNames[i], value);
                 }
             }
 

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
@@ -2935,8 +2935,8 @@ public class JdbcDao implements DonkeyDao {
             statement = connection.prepareStatement(querySource.getQuery("getMetaDataMapByMessageId", values));
             resultSet = statement.executeQuery();
 
-            MetaDataColumnType[] columnTypes = null;
-            String[] columnNames = null;
+            // Cache column types and names once — the schema is the same for every row,
+            // so calling getColumnType()/getColumnName() per row is wasteful.
             ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
             int columnCount = resultSetMetaData.getColumnCount();
             MetaDataColumnType[] columnTypes = new MetaDataColumnType[columnCount];

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
@@ -2935,8 +2935,6 @@ public class JdbcDao implements DonkeyDao {
             statement = connection.prepareStatement(querySource.getQuery("getMetaDataMapByMessageId", values));
             resultSet = statement.executeQuery();
 
-            // Cache column types and names once — the schema is the same for every row,
-            // so calling getColumnType()/getColumnName() per row is wasteful.
             ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
             int columnCount = resultSetMetaData.getColumnCount();
             MetaDataColumnType[] columnTypes = new MetaDataColumnType[columnCount];

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/JdbcDao.java
@@ -2937,11 +2937,11 @@ public class JdbcDao implements DonkeyDao {
 
             ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
             int columnCount = resultSetMetaData.getColumnCount();
-            MetaDataColumnType[] columnTypes = new MetaDataColumnType[columnCount];
-            String[] columnNames = new String[columnCount];
-            for (int i = 0; i < columnCount; i++) {
-                columnTypes[i] = MetaDataColumnType.fromSqlType(resultSetMetaData.getColumnType(i + 1));
-                columnNames[i] = resultSetMetaData.getColumnName(i + 1).toUpperCase();
+            MetaDataColumnType[] columnTypes = new MetaDataColumnType[columnCount + 1];
+            String[] columnNames = new String[columnCount + 1];
+            for (int i = 1; i <= columnCount; i++) {
+                columnTypes[i] = MetaDataColumnType.fromSqlType(resultSetMetaData.getColumnType(i));
+                columnNames[i] = resultSetMetaData.getColumnName(i).toUpperCase();
             }
 
             while (resultSet.next()) {
@@ -2960,13 +2960,12 @@ public class JdbcDao implements DonkeyDao {
                     connectorMetaDataMap.put(metaDataId, metaDataMap);
                 }
 
-                for (int i = 0; i < columnCount; i++) {
+                for (int i = 1; i <= columnCount; i++) {
                     Object value = null;
-                    int colIndex = i + 1;
 
                     switch (columnTypes[i]) {//@formatter:off
                         case STRING:
-                            value = resultSet.getString(colIndex);
+                            value = resultSet.getString(i);
                             if (encryptor != null && StringUtils.startsWith((String) value, Encryptor.HEADER_INDICATOR)) {
                                 try {
                                     value = encryptor.decrypt((String) value);
@@ -2975,11 +2974,11 @@ public class JdbcDao implements DonkeyDao {
                                 }
                             }
                             break;
-                        case NUMBER: value = resultSet.getBigDecimal(colIndex); break;
-                        case BOOLEAN: value = resultSet.getBoolean(colIndex); break;
+                        case NUMBER: value = resultSet.getBigDecimal(i); break;
+                        case BOOLEAN: value = resultSet.getBoolean(i); break;
                         case TIMESTAMP:
 
-                            Timestamp timestamp = resultSet.getTimestamp(colIndex);
+                            Timestamp timestamp = resultSet.getTimestamp(i);
                             if (timestamp != null) {
                                 value = Calendar.getInstance();
                                 ((Calendar) value).setTimeInMillis(timestamp.getTime());


### PR DESCRIPTION
Cache ResultSetMetaData (column count, types, and names) before iterating rows so getColumnType/getColumnName are not called for every row. Adjust column indexing and decryption logging to use the cached metadata. This reduces repeated metadata calls and improves performance when reading connector metadata from the database.
