### PR TITLE
fix: handle clipboard Error when image is in clipboard (#196)

### DIFF
--- a/client/src/com/mirth/connect/client/ui/actions/PasteAction.java
+++ b/client/src/com/mirth/connect/client/ui/actions/PasteAction.java
@@ -17,11 +17,15 @@ import java.awt.event.ActionEvent;
 
 import javax.swing.AbstractAction;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.mirth.connect.client.ui.components.MirthTextInterface;
 
 /** Allows for Pasting in text components. */
 public class PasteAction extends AbstractAction {
 
+    private static final Logger logger = LogManager.getLogger(PasteAction.class);
     MirthTextInterface comp;
 
     public PasteAction(MirthTextInterface comp) {
@@ -45,6 +49,9 @@ public class PasteAction extends AbstractAction {
                 }
                 return false;
             } catch (IllegalStateException e) {
+                return false;
+            } catch (Error e) {
+                logger.warn("Could not check clipboard contents.", e);
                 return false;
             }
         } else {


### PR DESCRIPTION
## Summary

- `PasteAction.isEnabled()` calls `clipboard.getContents()` to check for pasteable content, which triggers JAI's `PNMImageWriter` initialization on Linux
- `PNMImageWriter` attempts to access `sun.security.action.GetPropertyAction`, a sealed internal JDK class, throwing `IllegalAccessError` under Java 17
- The existing catch only handled `IllegalStateException`, so the `Error` propagated up and crashed the Admin UI on login
- Added a `catch (Error e)` block that logs a warning and returns `false`, keeping the paste action disabled without crashing

Fixes #196

## Test plan

- [ ] Copy an image to clipboard (e.g. right-click → Copy Image in a browser)
- [ ] Launch OIE Admin
- [ ] Verify login succeeds and no crash occurs
- [ ] Verify paste still works normally when text is on the clipboard