### PR TITLE
Fix: bug in JXTreeTable.getEditingRow

### DIFF
--- a/client/src/com/mirth/connect/client/ui/SortableTreeTable.java
+++ b/client/src/com/mirth/connect/client/ui/SortableTreeTable.java
@@ -1,11 +1,6 @@
-/*
- * Copyright (c) Mirth Corporation. All rights reserved.
- * 
- * http://www.mirthcorp.com
- * 
- * The software in this package is published under the terms of the MPL license a copy of which has
- * been included with this distribution in the LICENSE.txt file.
- */
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Mirth Corporation
+// SPDX-FileCopyrightText: 2026 Tony Germano <tony@germano.name>
 
 package com.mirth.connect.client.ui;
 
@@ -133,6 +128,18 @@ public class SortableTreeTable extends JXTreeTable {
     @Override
     public void setSortOrder(int columnIndex, SortOrder sortOrder) {
         sortModel.setSortOptions(sortModel.getColumnName(columnIndex), order);
+    }
+
+    // This fixes a bug in the super implementation where isHierarchical(int) can be
+    // called when editingColumn has a value of -1, which causes an exception to be
+    // thrown.
+    @Override
+    public int getEditingRow() {
+        if (editingRow == -1 || editingColumn == -1 || isHierarchical(editingColumn)) {
+            return -1;
+        } else {
+            return editingRow;
+        }
     }
 
     // ======================================================= private methods


### PR DESCRIPTION
org.jdesktop.swingx.JXTreeTable contains the following (decompiled) methods

    public boolean isHierarchical(int column) {
       if (column >= 0 && column < this.getColumnCount()) {
          return this.getHierarchicalColumn() == column;
       } else {
          throw new IllegalArgumentException("column must be valid, was" + column);
       }
    }

    public int getEditingRow() {
       if (this.editingRow == -1) {
          return -1;
       } else {
          return this.isHierarchical(this.editingColumn) ? -1 : this.editingRow;
       }
    }

Exceptions are thrown, especially on macOS clients, when getEditingRow is called while not editing, causing isHeirarchical to be called when editingColumn is -1.

This commit overrides getEditingRow to protect against that condition.

Fixes https://github.com/OpenIntegrationEngine/engine/issues/272

Several issues with similar stack traces have been logged against Mirth and Bridgelink over the past few years.