### PR TITLE
Avoid having the version spread everywhere

### DIFF
--- a/command/tests/extensionsTest/extensionWithLibsAtRoot/plugin.xml
+++ b/command/tests/extensionsTest/extensionWithLibsAtRoot/plugin.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithLibsAtRootAndSubfolder/destination.xml
+++ b/command/tests/extensionsTest/extensionWithLibsAtRootAndSubfolder/destination.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithMultileSharedLibsFromDifferentXml/destination.xml
+++ b/command/tests/extensionsTest/extensionWithMultileSharedLibsFromDifferentXml/destination.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithMultileSharedLibsFromDifferentXml/plugin.xml
+++ b/command/tests/extensionsTest/extensionWithMultileSharedLibsFromDifferentXml/plugin.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithMultileSharedLibsFromDifferentXml/source.xml
+++ b/command/tests/extensionsTest/extensionWithMultileSharedLibsFromDifferentXml/source.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithNoSharedLibs/source.xml
+++ b/command/tests/extensionsTest/extensionWithNoSharedLibs/source.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithSameLibReferencedFromDifferentXml/plugin.xml
+++ b/command/tests/extensionsTest/extensionWithSameLibReferencedFromDifferentXml/plugin.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/command/tests/extensionsTest/extensionWithSameLibReferencedFromDifferentXml/source.xml
+++ b/command/tests/extensionsTest/extensionWithSameLibReferencedFromDifferentXml/source.xml
@@ -2,7 +2,7 @@
 	<name>TEST Plugin</name>
 	<author>Mirth Corporation</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>99.99.99</mirthVersion>
 	<url>http://www.mirthcorp.com</url>
 	<description>Fake plugin.xml to test shared library loading</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/connectors/dimse/destination.xml
+++ b/server/src/com/mirth/connect/connectors/dimse/destination.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to send messages using DICOM protocol.</description>
 	<clientClassName>com.mirth.connect.connectors.dimse.DICOMSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/dimse/source.xml
+++ b/server/src/com/mirth/connect/connectors/dimse/source.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to listen for incoming messages over a standard TCP connection.</description>
 	<clientClassName>com.mirth.connect.connectors.dimse.DICOMListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/doc/destination.xml
+++ b/server/src/com/mirth/connect/connectors/doc/destination.xml
@@ -2,7 +2,7 @@
 	<name>Document Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to create RTF or PDF documents based on an HTML template. PDF files can be password protected.</description>
 	<clientClassName>com.mirth.connect.connectors.doc.DocumentWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/file/destination.xml
+++ b/server/src/com/mirth/connect/connectors/file/destination.xml
@@ -2,7 +2,7 @@
 	<name>File Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to write files to a local or network file system. A velocity template is available to dynamically generate files.</description>
 	<clientClassName>com.mirth.connect.connectors.file.FileWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/file/source.xml
+++ b/server/src/com/mirth/connect/connectors/file/source.xml
@@ -2,7 +2,7 @@
 	<name>File Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to poll for files from a local or network file system.</description>
 	<clientClassName>com.mirth.connect.connectors.file.FileReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/http/destination.xml
+++ b/server/src/com/mirth/connect/connectors/http/destination.xml
@@ -2,7 +2,7 @@
 	<name>HTTP Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to send messages to an HTTP server. Custom header properties can be specified.</description>
 	<clientClassName>com.mirth.connect.connectors.http.HttpSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/http/source.xml
+++ b/server/src/com/mirth/connect/connectors/http/source.xml
@@ -2,7 +2,7 @@
 	<name>HTTP Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to listen for incoming HTTP data. Messages are received as XML and include the full header contents.</description>
 	<clientClassName>com.mirth.connect.connectors.http.HttpListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jdbc/destination.xml
+++ b/server/src/com/mirth/connect/connectors/jdbc/destination.xml
@@ -2,7 +2,7 @@
 	<name>Database Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to write to any JDBC-compatabile database with Insert, Update or JavaScript statements.</description>
 	<clientClassName>com.mirth.connect.connectors.jdbc.DatabaseWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jdbc/source.xml
+++ b/server/src/com/mirth/connect/connectors/jdbc/source.xml
@@ -2,7 +2,7 @@
 	<name>Database Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to poll any supported JDBC-compatabile database for data. Rows are returned as XML and JavaScript can be used for advanced logic.</description>
 	<clientClassName>com.mirth.connect.connectors.jdbc.DatabaseReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jms/destination.xml
+++ b/server/src/com/mirth/connect/connectors/jms/destination.xml
@@ -2,7 +2,7 @@
 	<name>JMS Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to write messages to a JMS queue.</description>
 	<clientClassName>com.mirth.connect.connectors.jms.JmsSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jms/source.xml
+++ b/server/src/com/mirth/connect/connectors/jms/source.xml
@@ -2,7 +2,7 @@
 	<name>JMS Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to read messages from a JMS queue.</description>
 	<clientClassName>com.mirth.connect.connectors.jms.JmsListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/js/destination.xml
+++ b/server/src/com/mirth/connect/connectors/js/destination.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to execute JavaScript to connect to an arbitrary destination.</description>
 	<clientClassName>com.mirth.connect.connectors.js.JavaScriptWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/js/source.xml
+++ b/server/src/com/mirth/connect/connectors/js/source.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to execute arbitrary JavaScript to pull in messages to a channel.</description>
 	<clientClassName>com.mirth.connect.connectors.js.JavaScriptReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/smtp/destination.xml
+++ b/server/src/com/mirth/connect/connectors/smtp/destination.xml
@@ -2,7 +2,7 @@
 	<name>SMTP Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to send email messages via SMTP. A template is available to dynamically create messages.</description>
 	<clientClassName>com.mirth.connect.connectors.smtp.SmtpSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/tcp/destination.xml
+++ b/server/src/com/mirth/connect/connectors/tcp/destination.xml
@@ -2,7 +2,7 @@
 	<name>TCP Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to send messages to a TCP server.</description>
 	<clientClassName>com.mirth.connect.connectors.tcp.TcpSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/tcp/plugin.xml
+++ b/server/src/com/mirth/connect/connectors/tcp/plugin.xml
@@ -2,7 +2,7 @@
 	<name>TCP Connector Service Plugin</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin is required for correct use of the TCP connectors.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/connectors/tcp/source.xml
+++ b/server/src/com/mirth/connect/connectors/tcp/source.xml
@@ -2,7 +2,7 @@
 	<name>TCP Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to listen for incoming messages over a standard TCP connection.</description>
 	<clientClassName>com.mirth.connect.connectors.tcp.TcpListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/vm/destination.xml
+++ b/server/src/com/mirth/connect/connectors/vm/destination.xml
@@ -2,7 +2,7 @@
 	<name>Channel Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to send events to other channels in the same Open Integration Engine instance.</description>
 	<clientClassName>com.mirth.connect.connectors.vm.ChannelWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/vm/source.xml
+++ b/server/src/com/mirth/connect/connectors/vm/source.xml
@@ -2,7 +2,7 @@
 	<name>Channel Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to listen for incoming events from other channels in the same Open Integration Engine instance.</description>
 	<clientClassName>com.mirth.connect.connectors.vm.ChannelReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/ws/destination.xml
+++ b/server/src/com/mirth/connect/connectors/ws/destination.xml
@@ -2,7 +2,7 @@
 	<name>Web Service Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to invoke remote Web Services over HTTP.</description>
 	<clientClassName>com.mirth.connect.connectors.ws.WebServiceSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/ws/source.xml
+++ b/server/src/com/mirth/connect/connectors/ws/source.xml
@@ -2,7 +2,7 @@
 	<name>Web Service Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This connector allows Open Integration Engine to listen on an HTTP port for incoming Web Service calls. This connector also provides a WSDL for SOAP clients to use.</description>
 	<clientClassName>com.mirth.connect.connectors.ws.WebServiceListener</clientClassName>

--- a/server/src/com/mirth/connect/plugins/dashboardstatus/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/dashboardstatus/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Dashboard Connector Status Monitor</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a real-time connection status column on the Open Integration Engine client</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datapruner/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datapruner/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Data Pruner</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides data pruning capability for Open Integration Engine</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/delimited/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/delimited/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Delimited Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the delimited data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/dicom/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/dicom/plugin.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the DICOM data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/edi/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/edi/plugin.xml
@@ -2,7 +2,7 @@
 	<name>EDI Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the EDI data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/hl7v2/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/hl7v2/plugin.xml
@@ -2,7 +2,7 @@
 	<name>HL7v2 Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the HL7v2 data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/hl7v3/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/hl7v3/plugin.xml
@@ -2,7 +2,7 @@
 	<name>HL7v3 Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the HL7v3 data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/json/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/json/plugin.xml
@@ -2,7 +2,7 @@
 	<name>JSON Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the JSON data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/ncpdp/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/ncpdp/plugin.xml
@@ -2,7 +2,7 @@
 	<name>NCPDP Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the NCPDP data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/raw/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/raw/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Raw Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the raw data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/xml/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/xml/plugin.xml
@@ -2,7 +2,7 @@
 	<name>XML Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides support for the XML data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/destinationsetfilter/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/destinationsetfilter/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Destination Set Filter Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>Provides an easy method in the source transformer to filter destinations from being executed.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/dicomviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/dicomviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides DICOM attachment viewing capability in message browser</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/directoryresource/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/directoryresource/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Directory Resource Plugin</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin allows a directory to be used as a source for libraries to include in channels.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/globalmapviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/globalmapviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Global Map Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin allows you to view the global map and global channel maps in the Open Integration Engine Administrator.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/httpauth/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/httpauth/plugin.xml
@@ -2,7 +2,7 @@
 	<name>HTTP Authentication Settings</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides advanced authentication support for HTTP-based source connectors.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/imageviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/imageviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Image Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides image attachment viewing capability in message browser.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/javascriptrule/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/javascriptrule/plugin.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Filter Rule</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a JavaScript rule-type for Open Integration Engine filters</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/javascriptstep/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/javascriptstep/plugin.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a JavaScript step-type for Open Integration Engine transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/mapper/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/mapper/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Mapper Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a Mapping step type for Open Integration Engine transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/messagebuilder/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/messagebuilder/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Message Builder Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a Message Builder step-type for Open Integration Engine transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/mllpmode/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/mllpmode/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Transmission Mode - MLLP</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides an MLLP transmission mode for socket/serial connectors.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/pdfviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/pdfviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>PDF Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides PDF attachment viewing capability in message browser.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/rulebuilder/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/rulebuilder/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Rule Builder Filter Rule</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a Rule Builder type for Open Integration Engine filters</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/scriptfilerule/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/scriptfilerule/plugin.xml
@@ -2,7 +2,7 @@
 	<name>External Script Filter Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides an External Script step-type for Open Integration Engine filters</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/scriptfilestep/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/scriptfilestep/plugin.xml
@@ -2,7 +2,7 @@
 	<name>External Script Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides an External Script step-type for Open Integration Engine transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/serverlog/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/serverlog/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Server Log</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin allows you to view the server log on the Open Integration Engine administrator.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/textviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/textviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Text Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides text and RTF attachment viewing capability in message browser.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/xsltstep/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/xsltstep/plugin.xml
@@ -2,7 +2,7 @@
 	<name>XSLT Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>4.5.2</mirthVersion>
+	<mirthVersion>@mirthversion</mirthVersion>
 	<url>https://openintegrationengine.org</url>
 	<description>This plugin provides a XSLT support step-type for Open Integration Engine transformers</description>
 	<clientClasses>

--- a/server/test/com/mirth/connect/client/core/ConnectServiceUtilTest.java
+++ b/server/test/com/mirth/connect/client/core/ConnectServiceUtilTest.java
@@ -164,7 +164,7 @@ public class ConnectServiceUtilTest {
     @Test
     public void test_filterNotifications_currentVersionNewerThanAllOther() throws Exception {
         HttpEntity entity = createEntityFromFile(FILE_POPULATED);
-        Version current = Version.parse("4.6.0");
+        Version current = Version.parse("100.0.0");
         Stream<JsonNode> notifications = ConnectServiceUtil.toJsonStream(entity)
                 .filter(ConnectServiceUtil.dropOlderThan(current));
         assertEquals("Expected no notifications given a current version newer than all others", 0L, notifications.count());
@@ -182,7 +182,7 @@ public class ConnectServiceUtilTest {
     @Test
     public void test_filterNotifications_matchingLatestVersion() throws Exception {
         HttpEntity entity = createEntityFromFile(FILE_POPULATED);
-        Version current = Version.parse("4.5.2");
+        Version current = Version.parse("99.99.99");
         Stream<JsonNode> notifications = ConnectServiceUtil.toJsonStream(entity)
                 .filter(ConnectServiceUtil.dropOlderThan(current));
         assertEquals("Expected no notifications given a current version matching the latest in other list", 0L, notifications.count());

--- a/server/test/com/mirth/connect/server/servlets/WebStartServletTest.java
+++ b/server/test/com/mirth/connect/server/servlets/WebStartServletTest.java
@@ -542,8 +542,8 @@ public class WebStartServletTest {
 		return input.trim().replaceAll("[\\s\\r\\n ]+", " ");
 	}
 
-	private static String CORE_JNLP = "<jnlp codebase=\"https://localhost:8443\" version=\"4.5.2\">\n"
-			+ "	<information>\n" + "		<title>Mirth Connect Administrator 4.5.2</title>\n"
+	private static String CORE_JNLP = "<jnlp codebase=\"https://localhost:8443\" version=\"99.99.99\">\n"
+			+ "	<information>\n" + "		<title>Mirth Connect Administrator 99.99.99</title>\n"
 			+ "		<vendor>NextGen Healthcare</vendor>\n" + "		<homepage href=\"http://www.nextgen.com\"/>\n"
 			+ "		<description>Open Source Healthcare Integration Engine</description>\n" + "		\n"
 			+ "		<icon href=\"images/NG_MC_Icon_128x128.png\"/>\n"
@@ -560,7 +560,7 @@ public class WebStartServletTest {
 			+ "        <jar download=\"eager\" href=\"webstart/client-lib/mirth-client-core.jar\" sha256=\"testsha256\"/>\n"
 			+ "        <extension href=\"webstart/extensions/test.jnlp\"/>\n" + "    </resources>\n" + "	\n"
 			+ "	<application-desc main-class=\"com.mirth.connect.client.ui.Mirth\">\n"
-			+ "        <argument>https://localhost:8443</argument>\n" + "        <argument>4.5.2</argument>\n"
+			+ "        <argument>https://localhost:8443</argument>\n" + "        <argument>99.99.99</argument>\n"
 			+ "    </application-desc>\n" + "</jnlp>";
 
 	private static String EXTENSION_JNLP = "<jnlp>\n" + "    <information>\n"

--- a/server/test/resources/notifications-populated.json
+++ b/server/test/resources/notifications-populated.json
@@ -3,7 +3,7 @@
     "url": "https://api.github.com/repos/nextgenhealthcare/connect/releases/176445080",
     "assets_url": "https://api.github.com/repos/nextgenhealthcare/connect/releases/176445080/assets",
     "upload_url": "https://uploads.github.com/repos/nextgenhealthcare/connect/releases/176445080/assets{?name,label}",
-    "html_url": "https://github.com/nextgenhealthcare/connect/releases/tag/4.5.2",
+    "html_url": "https://github.com/nextgenhealthcare/connect/releases/tag/99.99.99",
     "id": 176445080,
     "author": {
       "login": "jdonextgen",
@@ -27,9 +27,9 @@
       "site_admin": false
     },
     "node_id": "RE_kwDOCCE7Tc4KhFaY",
-    "tag_name": "4.5.2",
+    "tag_name": "99.99.99",
     "target_commitish": "development",
-    "name": "Mirth Connect 4.5.2",
+    "name": "Mirth Connect 99.99.99",
     "draft": false,
     "prerelease": false,
     "created_at": "2024-09-10T13:12:21Z",
@@ -37,9 +37,9 @@
     "assets": [
 
     ],
-    "tarball_url": "https://api.github.com/repos/nextgenhealthcare/connect/tarball/4.5.2",
-    "zipball_url": "https://api.github.com/repos/nextgenhealthcare/connect/zipball/4.5.2",
-    "body_html": "<p>Mirth® Connect 4.5.2 is a patch release that includes enhancements, bug fixes, and security improvements. For more details, visit our See What's New and Release Notes pages linked below.</p>\n<p><strong>NOTICE: In 2025, Mirth® Connect will move to Java 17 as the minimum supported Java version.</strong></p>\n<p><a href=\"https://github.com/nextgenhealthcare/connect/wiki/4.5.2---What's-New\">See What's New</a> | <a href=\"https://github.com/nextgenhealthcare/connect/wiki/Upgrading\">Upgrade Guide</a> | <a href=\"https://github.com/nextgenhealthcare/connect/milestone/85?closed=1\">Release Notes</a></p>",
+    "tarball_url": "https://api.github.com/repos/nextgenhealthcare/connect/tarball/99.99.99",
+    "zipball_url": "https://api.github.com/repos/nextgenhealthcare/connect/zipball/99.99.99",
+    "body_html": "<p>Mirth® Connect 99.99.99 is a patch release that includes enhancements, bug fixes, and security improvements. For more details, visit our See What's New and Release Notes pages linked below.</p>\n<p><strong>NOTICE: In 2025, Mirth® Connect will move to Java 17 as the minimum supported Java version.</strong></p>\n<p><a href=\"https://github.com/nextgenhealthcare/connect/wiki/99.99.99---What's-New\">See What's New</a> | <a href=\"https://github.com/nextgenhealthcare/connect/wiki/Upgrading\">Upgrade Guide</a> | <a href=\"https://github.com/nextgenhealthcare/connect/milestone/85?closed=1\">Release Notes</a></p>",
     "discussion_url": "https://github.com/nextgenhealthcare/connect/discussions/6310"
   },
   {

--- a/tools/install4j/readme.html
+++ b/tools/install4j/readme.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <body style="font-family: Arial, sans-serif; line-height: 1.6; margin: 1em; background-color: white; color: black;">
-  <h1 style="color: black;">Open Integration Engine - 4.5.2 Release</h1>
-  <p>Open Integration Engine 4.5.2</p>
+  <h1 style="color: black;">Open Integration Engine</h1>
+  <p>Open Integration Engine</p>
   <p>
     This installer sets up a fully functional version of the engine with minimal user input.
     The installer requires administrator permissions to run and install services.


### PR DESCRIPTION
Centralizes to the existing `mirth-build.properties` `version` property.

Shifts tests to using 99.99.99 as the version to avoid confusion.