### PR TITLE
Speed up jnlp launch by 58%

### DIFF
--- a/server/src/com/mirth/connect/server/MirthWebServer.java
+++ b/server/src/com/mirth/connect/server/MirthWebServer.java
@@ -347,7 +347,6 @@ public class MirthWebServer extends Server {
         servletContextHandler.addFilter(new FilterHolder(new MethodFilter()), "/*", EnumSet.of(DispatcherType.REQUEST));
         servletContextHandler.addServlet(new ServletHolder(new WebStartServlet()), "/webstart.jnlp");
         servletContextHandler.addServlet(new ServletHolder(new WebStartServlet()), "/webstart");
-        servletContextHandler.addServlet(new ServletHolder(new WebStartServlet()), "/webstart/extensions/*");
         handlers.addHandler(servletContextHandler);
 
         // add the default handler for misc requests (favicon, etc.)

--- a/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
+++ b/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
@@ -264,9 +264,7 @@ public class WebStartServlet extends HttpServlet {
         }
 
         for (String extensionPath : extensionPathsToAddToJnlp) {
-            Element extensionElement = document.createElement("extension");
-            extensionElement.setAttribute("href", "webstart/extensions/" + extensionPath + ".jnlp");
-            resourcesElement.appendChild(extensionElement);
+            getExtensionJnlp(extensionPath, document, resourcesElement);
         }
 
         Element applicationDescElement = (Element) jnlpElement.getElementsByTagName("application-desc").item(0);
@@ -320,23 +318,12 @@ public class WebStartServlet extends HttpServlet {
         List<MetaData> allExtensions = new ArrayList<MetaData>();
         allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getConnectorMetaData().values());
         allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getPluginMetaData().values());
-        Set<String> librariesToAddToJnlp = new HashSet<String>();
         List<String> extensionsWithThePath = new ArrayList<String>();
 
         for (MetaData metaData : allExtensions) {
             if (metaData.getPath().equals(extensionPath)) {
                 extensionsWithThePath.add(metaData.getName());
-
-                for (ExtensionLibrary library : metaData.getLibraries()) {
-                    if (library.getType().equals(ExtensionLibrary.Type.CLIENT) || library.getType().equals(ExtensionLibrary.Type.SHARED)) {
-                        librariesToAddToJnlp.add(library.getPath());
-                    }
-                }
             }
-        }
-
-        if (extensionsWithThePath.isEmpty()) {
-            throw new Exception("Extension metadata could not be located for the path: " + extensionPath);
         }
 
         DocumentBuilderFactory dbf = getSecureDocumentBuilderFactory();
@@ -361,21 +348,50 @@ public class WebStartServlet extends HttpServlet {
 
         Element resourcesElement = document.createElement("resources");
 
-        File extensionDirectory = new File(ExtensionController.getExtensionsPath() + extensionPath);
-
-        for (String library : librariesToAddToJnlp) {
-            Element jarElement = document.createElement("jar");
-            jarElement.setAttribute("download", "eager");
-            // this path is relative to the servlet path
-            jarElement.setAttribute("href", "libs/" + extensionPath + "/" + library);
-            jarElement.setAttribute("sha256", getDigest(extensionDirectory, library));
-            resourcesElement.appendChild(jarElement);
-        }
+        getExtensionJnlp(extensionPath, document, resourcesElement, "libs/");
 
         jnlpElement.appendChild(resourcesElement);
         jnlpElement.appendChild(document.createElement("component-desc"));
         document.appendChild(jnlpElement);
         return document;
+    }
+
+    protected void getExtensionJnlp(String extensionPath, Document document, Element resourcesElement) throws Exception {
+        getExtensionJnlp(extensionPath, document, resourcesElement, "webstart/extensions/libs/");
+    }
+
+    private void getExtensionJnlp(String extensionPath, Document document, Element resourcesElement, String libraryPathPrefix) throws Exception {
+        List<MetaData> allExtensions = new ArrayList<MetaData>();
+        allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getConnectorMetaData().values());
+        allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getPluginMetaData().values());
+        Set<String> librariesToAddToJnlp = new HashSet<String>();
+        List<String> extensionsWithThePath = new ArrayList<String>();
+
+        for (MetaData metaData : allExtensions) {
+            if (metaData.getPath().equals(extensionPath)) {
+                extensionsWithThePath.add(metaData.getName());
+
+                for (ExtensionLibrary library : metaData.getLibraries()) {
+                    if (library.getType().equals(ExtensionLibrary.Type.CLIENT) || library.getType().equals(ExtensionLibrary.Type.SHARED)) {
+                        librariesToAddToJnlp.add(library.getPath());
+                    }
+                }
+            }
+        }
+
+        if (extensionsWithThePath.isEmpty()) {
+            throw new Exception("Extension metadata could not be located for the path: " + extensionPath);
+        }
+
+        File extensionDirectory = new File(ExtensionController.getExtensionsPath() + extensionPath);
+
+        for (String library : librariesToAddToJnlp) {
+            Element jarElement = document.createElement("jar");
+            jarElement.setAttribute("download", "eager");
+            jarElement.setAttribute("href", libraryPathPrefix + extensionPath + "/" + library);
+            jarElement.setAttribute("sha256", getDigest(extensionDirectory, library));
+            resourcesElement.appendChild(jarElement);
+        }
     }
 
     private String getDigest(File directory, String filePath) throws Exception {

--- a/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
+++ b/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import com.mirth.connect.client.core.BrandingConstants;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
@@ -85,10 +84,6 @@ public class WebStartServlet extends HttpServlet {
             if ((request.getRequestURI().equals(contextPathProp + "/webstart.jnlp") || request.getRequestURI().equals(contextPathProp + "/webstart")) && isWebstartRequestValid(request)) {
                 jnlpDocument = getAdministratorJnlp(request);
                 response.setHeader("Content-Disposition", "attachment; filename = \"webstart.jnlp\"");
-            } else if (request.getServletPath().equals("/webstart/extensions") && isWebstartExtensionsRequestValid(request, contextPathProp)) {
-                String extensionPath = getExtensionPath(request);
-                jnlpDocument = getExtensionJnlp(getExtensionPath(request));
-                response.setHeader("Content-Disposition", "attachment; filename = \"" + extensionPath +  ".jnlp\"");
             } else {
             	response.setContentType("");
             }
@@ -123,16 +118,6 @@ public class WebStartServlet extends HttpServlet {
         return true;
     }
     
-    private boolean isWebstartExtensionsRequestValid(HttpServletRequest request, String contextPathProp) {
-        // Don't allow any parameters and don't allow modified URIs
-        return request.getParameterMap().isEmpty() 
-                && (contextPathProp + request.getServletPath() + "/" + getExtensionPath(request)).equals(StringUtils.removeEnd(request.getRequestURI(), ".jnlp"));
-    }
-    
-    private String getExtensionPath(HttpServletRequest request) {
-    	return StringUtils.removeEnd(StringUtils.removeStart(request.getPathInfo(), "/"), ".jnlp");
-    }
-
     protected Document getAdministratorJnlp(HttpServletRequest request) throws Exception {
         InputStream clientJnlpIs = null;
         Document document;
@@ -314,53 +299,7 @@ public class WebStartServlet extends HttpServlet {
         return false;
     }
 
-    protected Document getExtensionJnlp(String extensionPath) throws Exception {
-        List<MetaData> allExtensions = new ArrayList<MetaData>();
-        allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getConnectorMetaData().values());
-        allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getPluginMetaData().values());
-        List<String> extensionsWithThePath = new ArrayList<String>();
-
-        for (MetaData metaData : allExtensions) {
-            if (metaData.getPath().equals(extensionPath)) {
-                extensionsWithThePath.add(metaData.getName());
-            }
-        }
-
-        DocumentBuilderFactory dbf = getSecureDocumentBuilderFactory();
-        Document document = dbf.newDocumentBuilder().newDocument();
-        Element jnlpElement = document.createElement("jnlp");
-
-        Element informationElement = document.createElement("information");
-
-        Element titleElement = document.createElement("title");
-        titleElement.setTextContent("Mirth Connect Extension - [" + StringUtils.join(extensionsWithThePath, ",") + "]");
-        informationElement.appendChild(titleElement);
-
-        Element vendorElement = document.createElement("vendor");
-        vendorElement.setTextContent(BrandingConstants.COMPANY_NAME);
-        informationElement.appendChild(vendorElement);
-
-        jnlpElement.appendChild(informationElement);
-
-        Element securityElement = document.createElement("security");
-        securityElement.appendChild(document.createElement("all-permissions"));
-        jnlpElement.appendChild(securityElement);
-
-        Element resourcesElement = document.createElement("resources");
-
-        getExtensionJnlp(extensionPath, document, resourcesElement, "libs/");
-
-        jnlpElement.appendChild(resourcesElement);
-        jnlpElement.appendChild(document.createElement("component-desc"));
-        document.appendChild(jnlpElement);
-        return document;
-    }
-
-    protected void getExtensionJnlp(String extensionPath, Document document, Element resourcesElement) throws Exception {
-        getExtensionJnlp(extensionPath, document, resourcesElement, "webstart/extensions/libs/");
-    }
-
-    private void getExtensionJnlp(String extensionPath, Document document, Element resourcesElement, String libraryPathPrefix) throws Exception {
+    private void getExtensionJnlp(String extensionPath, Document document, Element resourcesElement) throws Exception {
         List<MetaData> allExtensions = new ArrayList<MetaData>();
         allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getConnectorMetaData().values());
         allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getPluginMetaData().values());
@@ -388,7 +327,7 @@ public class WebStartServlet extends HttpServlet {
         for (String library : librariesToAddToJnlp) {
             Element jarElement = document.createElement("jar");
             jarElement.setAttribute("download", "eager");
-            jarElement.setAttribute("href", libraryPathPrefix + extensionPath + "/" + library);
+            jarElement.setAttribute("href", "webstart/extensions/libs/" + extensionPath + "/" + library);
             jarElement.setAttribute("sha256", getDigest(extensionDirectory, library));
             resourcesElement.appendChild(jarElement);
         }

--- a/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
+++ b/server/src/com/mirth/connect/server/servlets/WebStartServlet.java
@@ -249,7 +249,7 @@ public class WebStartServlet extends HttpServlet {
         }
 
         for (String extensionPath : extensionPathsToAddToJnlp) {
-            getExtensionJnlp(extensionPath, document, resourcesElement);
+            getExtensionJnlp(extensionPath, allExtensions, document, resourcesElement);
         }
 
         Element applicationDescElement = (Element) jnlpElement.getElementsByTagName("application-desc").item(0);
@@ -299,16 +299,13 @@ public class WebStartServlet extends HttpServlet {
         return false;
     }
 
-    private void getExtensionJnlp(String extensionPath, Document document, Element resourcesElement) throws Exception {
-        List<MetaData> allExtensions = new ArrayList<MetaData>();
-        allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getConnectorMetaData().values());
-        allExtensions.addAll(ControllerFactory.getFactory().createExtensionController().getPluginMetaData().values());
+    private void getExtensionJnlp(String extensionPath, List<MetaData> allExtensions, Document document, Element resourcesElement) throws Exception {
         Set<String> librariesToAddToJnlp = new HashSet<String>();
-        List<String> extensionsWithThePath = new ArrayList<String>();
+        boolean foundExtensionPath = false;
 
         for (MetaData metaData : allExtensions) {
             if (metaData.getPath().equals(extensionPath)) {
-                extensionsWithThePath.add(metaData.getName());
+                foundExtensionPath = true;
 
                 for (ExtensionLibrary library : metaData.getLibraries()) {
                     if (library.getType().equals(ExtensionLibrary.Type.CLIENT) || library.getType().equals(ExtensionLibrary.Type.SHARED)) {
@@ -318,7 +315,7 @@ public class WebStartServlet extends HttpServlet {
             }
         }
 
-        if (extensionsWithThePath.isEmpty()) {
+        if (!foundExtensionPath) {
             throw new Exception("Extension metadata could not be located for the path: " + extensionPath);
         }
 

--- a/server/test/com/mirth/connect/server/servlets/WebStartServletTest.java
+++ b/server/test/com/mirth/connect/server/servlets/WebStartServletTest.java
@@ -203,91 +203,6 @@ public class WebStartServletTest {
 		assertNull(response.getHeader("Content-Disposition"));
 	}
 
-	@Test
-	public void testDoGetExtension() throws Exception {
-		// Test /webstart/extensions/testextension
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		when(request.getRequestURI()).thenReturn("/webstart/extensions/testextension");
-		when(request.getServletPath()).thenReturn("/webstart/extensions");
-		when(request.getPathInfo()).thenReturn("/testextension");
-		when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
-
-		TestHttpServletResponse response = new TestHttpServletResponse();
-
-		webStartServlet.doGet(request, response);
-
-		assertEquals(normalizeWhitespace(EXTENSION_JNLP), normalizeWhitespace(response.getResponseString()));
-		assertEquals("application/x-java-jnlp-file", response.getContentType());
-		assertEquals("no-cache", response.getHeader("Pragma"));
-		assertEquals("nosniff", response.getHeader("X-Content-Type-Options"));
-		assertEquals("attachment; filename = \"testextension.jnlp\"", response.getHeader("Content-Disposition"));
-
-		// Test /webstart/extensions/testextension.jnlp
-		request = mock(HttpServletRequest.class);
-		when(request.getRequestURI()).thenReturn("/webstart/extensions/testextension.jnlp");
-		when(request.getServletPath()).thenReturn("/webstart/extensions");
-		when(request.getPathInfo()).thenReturn("/testextension");
-		when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
-
-		response = new TestHttpServletResponse();
-
-		webStartServlet.doGet(request, response);
-
-		assertEquals(normalizeWhitespace(EXTENSION_JNLP), normalizeWhitespace(response.getResponseString()));
-		assertEquals("application/x-java-jnlp-file", response.getContentType());
-		assertEquals("no-cache", response.getHeader("Pragma"));
-		assertEquals("nosniff", response.getHeader("X-Content-Type-Options"));
-		assertEquals("attachment; filename = \"testextension.jnlp\"", response.getHeader("Content-Disposition"));
-	}
-
-	@Test
-	public void testDoGetExtensionQueryParams() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		when(request.getRequestURI()).thenReturn("/webstart/extensions/testextension");
-		when(request.getServletPath()).thenReturn("/webstart/extensions");
-		when(request.getPathInfo()).thenReturn("/testextension");
-
-		Map<String, String[]> parameters = new HashMap<>();
-		parameters.put("maxHeapSize", new String[] { "1024m" });
-
-		when(request.getParameterNames()).thenReturn(Collections.enumeration(parameters.keySet()));
-		when(request.getParameter(anyString())).thenAnswer(new Answer<String>() {
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				Object[] args = invocation.getArguments();
-				return parameters.get((String) args[0])[0];
-			}
-		});
-		when(request.getParameterMap()).thenReturn(parameters);
-
-		TestHttpServletResponse response = new TestHttpServletResponse();
-
-		webStartServlet.doGet(request, response);
-
-		assertEquals("", response.getResponseString().trim());
-		assertEquals("", response.getResponseString().trim());
-		assertEquals("", response.getContentType());
-		assertNull(response.getHeader("Content-Disposition"));
-	}
-
-	@Test
-	public void testDoGetExtensionModifiedURL() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		when(request.getRequestURI()).thenReturn("/webstart/extensions/testextension;rfd.bat");
-		when(request.getServletPath()).thenReturn("/webstart/extensions");
-		when(request.getPathInfo()).thenReturn("/testextension");
-		when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
-
-		TestHttpServletResponse response = new TestHttpServletResponse();
-
-		webStartServlet.doGet(request, response);
-
-		assertEquals("", response.getResponseString().trim());
-		assertEquals("", response.getResponseString().trim());
-		assertEquals("", response.getContentType());
-		assertNull(response.getHeader("Content-Disposition"));
-	}
-
 	private static class TestHttpServletResponse implements HttpServletResponse {
 
 		private String contentType;
@@ -521,13 +436,6 @@ public class WebStartServletTest {
 			return factory.newDocumentBuilder()
 					.parse(new ByteArrayInputStream(CORE_JNLP.getBytes()));
 		}
-
-		@Override
-		protected Document getExtensionJnlp(String extensionPath) throws Exception {
-	        DocumentBuilderFactory factory = getSecureDocumentBuilderFactory();
-			return factory.newDocumentBuilder()
-					.parse(new ByteArrayInputStream(EXTENSION_JNLP.getBytes()));
-		}
 	}
 	
 	private static DocumentBuilderFactory getSecureDocumentBuilderFactory() throws Exception {
@@ -558,16 +466,9 @@ public class WebStartServletTest {
 			+ "		<j2se href=\"http://java.sun.com/products/autodl/j2se\" max-heap-size=\"512m\" version=\"1.6+\"/>\n"
 			+ "	<jar download=\"eager\" href=\"webstart/client-lib/mirth-client.jar\" main=\"true\" sha256=\"0Lv3mOM4e10OBhk78/ST2CzHrXtm+EcZibxV7VfdbI8=\"/>\n"
 			+ "        <jar download=\"eager\" href=\"webstart/client-lib/mirth-client-core.jar\" sha256=\"testsha256\"/>\n"
-			+ "        <extension href=\"webstart/extensions/test.jnlp\"/>\n" + "    </resources>\n" + "	\n"
+			+ "        <jar download=\"eager\" href=\"webstart/extensions/libs/file/test-client.jar\" sha256=\"testsha256\"/>\n"
+			+ "        <jar download=\"eager\" href=\"webstart/extensions/libs/file/test-shared.jar\" sha256=\"testsha256\"/>\n" + "    </resources>\n" + "	\n"
 			+ "	<application-desc main-class=\"com.mirth.connect.client.ui.Mirth\">\n"
 			+ "        <argument>https://localhost:8443</argument>\n" + "        <argument>99.99.99</argument>\n"
 			+ "    </application-desc>\n" + "</jnlp>";
-
-	private static String EXTENSION_JNLP = "<jnlp>\n" + "    <information>\n"
-			+ "        <title>Mirth Connect Extension - [Test Writer,Test Reader]</title>\n"
-			+ "        <vendor>NextGen Healthcare</vendor>\n" + "    </information>\n" + "    <security>\n"
-			+ "        <all-permissions/>\n" + "    </security>\n" + "    <resources>\n"
-			+ "        <jar download=\"eager\" href=\"libs/file/test-client.jar\" sha256=\"testsha256\"/>\n"
-			+ "        <jar download=\"eager\" href=\"libs/file/test-shared.jar\" sha256=\"testsha256\"/>\n"
-			+ "    </resources>\n" + "    <component-desc/>\n" + "</jnlp>\n" + "";
 }


### PR DESCRIPTION
Speeds launch time by not requiring multiple round-trips for each plugin.  Classpath with ballista remained identical.  No obvious benefit to the historical design - presumed to be some Java Security Manager pipe dream.

| Scenario | Before | After | % change |
|---|---|---|---|
| Cold cache, 100ms latency | 8.9s | 3.7s | ↓58% |
| Warm cache, 100ms latency | 5.8s | 0.7s | ↓87% |

Mildly related: #197 