### PR TITLE
Feature/issue 261 export tags  -Prune unrelated channel IDs from exported channel tags

### DIFF
--- a/client/src/com/mirth/connect/client/ui/ChannelPanel.java
+++ b/client/src/com/mirth/connect/client/ui/ChannelPanel.java
@@ -1928,7 +1928,9 @@ public class ChannelPanel extends AbstractFramePanel {
         List<ChannelTag> channelTags = new ArrayList<ChannelTag>();
         for (ChannelTag channelTag : getCachedChannelTags()) {
             if (channelTag.getChannelIds().contains(channel.getId())) {
-                channelTags.add(channelTag);
+                ChannelTag exportTag = new ChannelTag(channelTag);
+                exportTag.setChannelIds(Collections.singleton(channel.getId()));
+                channelTags.add(exportTag);
             }
         }
 

--- a/server/src/com/mirth/connect/server/api/servlets/ChannelServlet.java
+++ b/server/src/com/mirth/connect/server/api/servlets/ChannelServlet.java
@@ -312,6 +312,11 @@ public class ChannelServlet extends MirthServlet implements ChannelServletInterf
             channel.getExportData().setChannelTags(channelTags
                     .stream()
                     .filter(tag -> tag.getChannelIds().contains(channel.getId()))
+                    .map(tag -> {
+                        ChannelTag exportTag = new ChannelTag(tag);
+                        exportTag.setChannelIds(Collections.singleton(channel.getId()));
+                        return exportTag;
+                    })
                     .collect(Collectors.toList()));
 
             channel.getExportData().setDependencyIds(channelDependencies

--- a/server/test/com/mirth/connect/server/api/servlets/ChannelServletTest.java
+++ b/server/test/com/mirth/connect/server/api/servlets/ChannelServletTest.java
@@ -200,8 +200,8 @@ public class ChannelServletTest extends ServletTestBase {
         assertEquals(Integer.valueOf(7), exportData.getMetadata().getPruningSettings().getPruneContentDays());
 
         assertEquals(2, exportData.getChannelTags().size());
-        assertTrue(exportData.getChannelTags().contains(new ChannelTag("tag1", "Tag 1", new HashSet<>(Arrays.asList(new String[] { CHANNEL_ID_1, CHANNEL_ID_2 })))));
-        assertTrue(exportData.getChannelTags().contains(new ChannelTag("tag2", "Tag 2", new HashSet<>(Arrays.asList(new String[] { CHANNEL_ID_1, CHANNEL_ID_3 })))));
+        assertTrue(exportData.getChannelTags().contains(new ChannelTag("tag1", "Tag 1", new HashSet<>(Arrays.asList(new String[] { CHANNEL_ID_1 })))));
+        assertTrue(exportData.getChannelTags().contains(new ChannelTag("tag2", "Tag 2", new HashSet<>(Arrays.asList(new String[] { CHANNEL_ID_1 })))));
 
         assertEquals(1, exportData.getDependencyIds().size());
         assertTrue(exportData.getDependencyIds().contains(CHANNEL_ID_2));
@@ -234,3 +234,4 @@ public class ChannelServletTest extends ServletTestBase {
     }
 
 }
+


### PR DESCRIPTION
 ## Summary
  Prunes exported channel tag membership so channel exports only include the exported channel's ID in each tag.

  ## Changes
  - prune tag channel IDs in server-side export assembly
  - prune tag channel IDs in client-side channel export
  - update ChannelServletTest expectations for exported tag membership

  ## Verification
  - ChannelServletTest passes when run directly (It was edited as part of this commit)
  - Rebuilt with Ant -DdisableTests=true
  - Tested the UI (windows 10) by exporting a single channel, importing, and exporting a group, importing. 