### PR TITLE
Use the dedicated ICON_CONNECTOR to represent a connector in the dashboard

### DIFF
--- a/client/src/com/mirth/connect/client/ui/TagTreeCellRenderer.java
+++ b/client/src/com/mirth/connect/client/ui/TagTreeCellRenderer.java
@@ -108,6 +108,8 @@ public class TagTreeCellRenderer extends JPanel implements TreeCellRenderer {
                 if (status.getStatusType() == StatusType.CHANNEL) {
                     icon = UIConstants.ICON_CHANNEL;
                     channel = true;
+                } else if (status.getStatusType() == StatusType.SOURCE_CONNECTOR || status.getStatusType() == StatusType.DESTINATION_CONNECTOR) {
+                    icon = UIConstants.ICON_CONNECTOR;
                 }
             }
         } else if (value instanceof ChannelTableNode) {


### PR DESCRIPTION
Fix #291

In the `TagTreeCellRenderer` class, this block (line 108):

```java
if (status.getStatusType() == StatusType.CHANNEL) {
    icon = UIConstants.ICON_CHANNEL;
    channel = true;
}
```

has been changed to this:

```java
if (status.getStatusType() == StatusType.CHANNEL) {
    icon = UIConstants.ICON_CHANNEL;
    channel = true;
} else if (status.getStatusType() == StatusType.SOURCE_CONNECTOR || status.getStatusType() == StatusType.DESTINATION_CONNECTOR) {
    icon = UIConstants.ICON_CONNECTOR;
}
```

The result is this:

<img width="393" height="253" alt="Icon_Connector_Screenshot 2026-04-08 004221" src="https://github.com/user-attachments/assets/fcd611ef-929d-4928-88f4-aa43b5c6750e" />

Instead of this:

<img width="395" height="248" alt="Icon_Channel_Screenshot 2026-04-08 004326" src="https://github.com/user-attachments/assets/9fc10d11-15ee-4c40-9eaa-31a27e7e2e32" />
