### PR TITLE
Prevent duplicate vmoptions from being added

### DIFF
--- a/server/basedir-includes/configure-from-env
+++ b/server/basedir-includes/configure-from-env
@@ -140,7 +140,9 @@ if ! [ -z "${VMOPTIONS+x}" ]; then
 
     for vmoption in "${vmoptions[@]}"
     do
-        echo "${vmoption}" >> "$APP_DIR/oieserver.vmoptions"
+        if ! grep -Fqsx -- "${vmoption}" "$APP_DIR/oieserver.vmoptions"; then
+            echo "${vmoption}" >> "$APP_DIR/oieserver.vmoptions"
+        fi
     done
 fi
 


### PR DESCRIPTION
Prevent duplicate entries in `oieserver.vmoptions`. Current behavior will infinitely re-append all VMOPTIONS every time the container starts, even if VMOPTIONS has not changed.

See also: [engine-docker#7](https://github.com/OpenIntegrationEngine/engine-docker/pull/7)