### PR TITLE
Set HikariCP connectionTimeout to 30s to prevent thread starvation

### DIFF
--- a/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/HikariConnectionPool.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/data/jdbc/HikariConnectionPool.java
@@ -28,7 +28,7 @@ public class HikariConnectionPool implements ConnectionPool {
         dataSource.setJdbcUrl(url);
         dataSource.setUsername(username);
         dataSource.setPassword(password);
-        dataSource.setConnectionTimeout(0);
+        dataSource.setConnectionTimeout(30000);
         dataSource.setAutoCommit(false);
         dataSource.setMaximumPoolSize(maxConnections);
         dataSource.setMinimumIdle(0);


### PR DESCRIPTION
Previously connectionTimeout was set to 0, which HikariCP interprets as
wait indefinitely for a pool connection. Under any connection pressure
this causes caller threads to block forever, silently starving the
application with no way to detect or recover from the condition.

Change the value to 30000 ms (30 seconds), which matches the HikariCP
default. Callers will now receive a SQLException after 30 s instead of
hanging, surfacing pool starvation quickly and allowing the application
to fail fast and recover.