### PR TITLE
Feature/admin user prefs

### DIFF
--- a/server/basedir-includes/configure-from-env
+++ b/server/basedir-includes/configure-from-env
@@ -114,8 +114,10 @@ while read -r keyvalue; do
 			ACTUAL_KEY="${ACTUAL_KEY//_/.}"
 
 			# lower case
-			# example:  database.max-connections
-			ACTUAL_KEY="${ACTUAL_KEY,,}"
+			# example:  database.max-connections (but not _MP_user_pref_default_showTags)
+			if [[ ! ${ACTUAL_KEY} =~ [a-z] ]]; then
+				ACTUAL_KEY="${ACTUAL_KEY,,}"
+			fi
 
 			# if key does not exist in mirth.properties append it at bottom
 			LINE_COUNT=`grep "^${ACTUAL_KEY}" "$APP_DIR/conf/mirth.properties" | wc -l`

--- a/server/src/com/mirth/connect/model/AdminUserPreference.java
+++ b/server/src/com/mirth/connect/model/AdminUserPreference.java
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Mitch Gaffigan
+
+package com.mirth.connect.model;
+
+/** Administrative policy for a user preference */
+public record AdminUserPreference(String value, boolean locked) {}

--- a/server/src/com/mirth/connect/server/controllers/ConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/ConfigurationController.java
@@ -21,6 +21,7 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import com.mirth.commons.encryption.Digester;
 import com.mirth.commons.encryption.Encryptor;
 import com.mirth.connect.client.core.ControllerException;
+import com.mirth.connect.model.AdminUserPreference;
 import com.mirth.connect.model.ChannelDependency;
 import com.mirth.connect.model.ChannelMetadata;
 import com.mirth.connect.model.ChannelTag;
@@ -334,6 +335,9 @@ public abstract class ConfigurationController extends Controller {
     }
 
     public abstract Properties getPropertiesForGroup(String group, Set<String> propertyKeys);
+
+    /** Get administratively set user preferences */
+    public abstract Map<String, AdminUserPreference> getUserPreferenceProperties();
 
     public abstract void removePropertiesForGroup(String group);
 

--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -99,6 +99,7 @@ import com.mirth.connect.client.core.PropertiesConfigurationUtil;
 import com.mirth.connect.donkey.model.DatabaseConstants;
 import com.mirth.connect.donkey.server.data.DonkeyStatisticsUpdater;
 import com.mirth.connect.donkey.util.DonkeyElement;
+import com.mirth.connect.model.AdminUserPreference;
 import com.mirth.connect.model.Channel;
 import com.mirth.connect.model.ChannelDependency;
 import com.mirth.connect.model.ChannelMetadata;
@@ -144,6 +145,8 @@ public class DefaultConfigurationController extends ConfigurationController {
     public static final String PROPERTIES_CHANNEL_METADATA = "channelMetadata";
     public static final String PROPERTIES_CHANNEL_TAGS = "channelTags";
     public static final String PROPERTIES_DATABASE_DRIVERS = "databaseDrivers";
+    private static final String USER_PREFERENCE_DEFAULT_PREFIX = "user.pref.default.";
+    private static final String USER_PREFERENCE_LOCK_PREFIX = "user.pref.lock.";
     public static final String SECRET_KEY_ALIAS = "encryption";
     public static final String VACUUM_LOCK_STATEMENT_ID = "Configuration.vacuumConfigurationTable";
 
@@ -1000,6 +1003,26 @@ public class DefaultConfigurationController extends ConfigurationController {
         }
 
         return properties;
+    }
+
+    @Override
+    public Map<String, AdminUserPreference> getUserPreferenceProperties() {
+        Properties coreProperties = getPropertiesForGroup(PROPERTIES_CORE);
+        Map<String, AdminUserPreference> policies = new HashMap<String, AdminUserPreference>();
+
+        for (String key : coreProperties.stringPropertyNames()) {
+            if (!key.startsWith(USER_PREFERENCE_DEFAULT_PREFIX)) {
+                continue;
+            }
+
+            String preferenceName = key.substring(USER_PREFERENCE_DEFAULT_PREFIX.length());
+            String value = coreProperties.getProperty(key);
+            boolean locked = Boolean.parseBoolean(coreProperties.getProperty(USER_PREFERENCE_LOCK_PREFIX + preferenceName));
+
+            policies.put(preferenceName, new AdminUserPreference(value, locked));
+        }
+
+        return policies;
     }
 
     public void removePropertiesForGroup(String category) {

--- a/server/src/com/mirth/connect/server/controllers/DefaultUserController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultUserController.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 
 import com.mirth.commons.encryption.Digester;
 import com.mirth.connect.client.core.ControllerException;
+import com.mirth.connect.model.AdminUserPreference;
 import com.mirth.connect.model.Credentials;
 import com.mirth.connect.model.LoginStatus;
 import com.mirth.connect.model.LoginStatus.Status;
@@ -560,11 +561,23 @@ public class DefaultUserController extends UserController {
         logger.debug("retrieving preferences: user id=" + userId);
         Properties properties = new Properties();
 
+        var policies = ControllerFactory.getFactory().createConfigurationController().getUserPreferenceProperties();
+        for (var entry : policies.entrySet()) {
+            if (CollectionUtils.isEmpty(names) || names.contains(entry.getKey())) {
+                properties.setProperty(entry.getKey(), StringUtils.defaultString(entry.getValue().value()));
+            }
+        }
+
         StatementLock.getInstance(VACUUM_LOCK_PREFERENCES_STATEMENT_ID).readLock();
         try {
             List<KeyValuePair> result = SqlConfig.getInstance().getReadOnlySqlSessionManager().selectList("User.selectPreferencesForUser", userId);
 
             for (KeyValuePair pair : result) {
+                var policy = policies.get(pair.getKey());
+                if (policy != null && policy.locked()) {
+                    continue;
+                }
+
                 if (CollectionUtils.isEmpty(names) || names.contains(pair.getKey())) {
                     properties.setProperty(pair.getKey(), StringUtils.defaultString(pair.getValue()));
                 }
@@ -582,6 +595,14 @@ public class DefaultUserController extends UserController {
     public String getUserPreference(Integer userId, String name) {
         logger.debug("retrieving preference: user id=" + userId + ", name=" + name);
 
+        var policy = ControllerFactory.getFactory().createConfigurationController().getUserPreferenceProperties().get(name);
+        policy = policy != null ? policy : new AdminUserPreference(null, false);
+
+        String value = policy.value();
+        if (policy.locked()) {
+            return value;
+        }
+        
         StatementLock.getInstance(VACUUM_LOCK_PREFERENCES_STATEMENT_ID).readLock();
         try {
             Map<String, Object> parameterMap = new HashMap<String, Object>();


### PR DESCRIPTION
This change lets administrators define policy-controlled user preferences in `mirth.properties`.

Administrators can now:

- Set a default value for a user preference with `user.pref.default.<name>`.
- Lock that preference with `user.pref.lock.<name>` so user-stored values are ignored.

Locked preferences are always returned from the server with the admin-defined value, even if a user has previously saved a different value. This is a server-side policy change only; existing user preferences remain in the database, but locked values may override them at read time.

If an admin wishes to lock a user preference to a particular value, the value must be specified.  "user.pref.lock" without "user.pref.default" has no effect.

Example `mirth.properties` edit:

```properties
# Default a user preference "showTags" to "true"
# Allow the user to override the default (since it is not locked)
user.pref.default.showTags = true

# Default messageBrowserPageSize to 50 and prevent user changes
user.pref.default.messageBrowserPageSize = 50
user.pref.lock.messageBrowserPageSize = true
```

or, via env:

```bash
_MP_user_pref_default_showTags=true
```

Closes #322