### PR TITLE
Add CODEOWNERS file to automate PR review requests in GitHub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @openintegrationengine/maintainers


### PR DESCRIPTION
Adds a [`CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to enable automatically requesting PR reviews from maintainers.