### PR TITLE
Add Dependabot config (Gradle + Docker) with grouping and verification-metadata automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,74 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Wait 2 days after a release before opening a PR, to skip yanked/broken versions.
+    cooldown:
+      default-days: 2
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "java"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # Groups are keyed at the coherent-project level. Note e.g. org.apache.* is NOT a
+    # single project — org.apache.commons, org.apache.logging.log4j, org.apache.pdfbox,
+    # etc. are unrelated and must not be bundled together, so patterns go three levels deep.
+    groups:
+      aws-sdk:
+        patterns:
+          - "software.amazon.awssdk:*"
+          - "software.amazon.eventstream:*"
+      jetty:
+        patterns:
+          - "org.eclipse.jetty*"
+      jersey:
+        patterns:
+          - "org.glassfish.jersey*"
+          - "org.glassfish.hk2*"
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*"
+      netty:
+        patterns:
+          - "io.netty*"
+          - "com.typesafe.netty*"
+      log4j:
+        patterns:
+          - "org.apache.logging.log4j*"
+      apache-commons:
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:*"
+      test-tooling:
+        patterns:
+          - "org.mockito*"
+          - "net.bytebuddy*"
+          - "org.objenesis:*"
+          - "org.hamcrest:*"
+          - "junit:*"
+      # Everything else: bundle only minor/patch so major bumps still arrive as
+      # individual PRs that get reviewed on their own.
+      all-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 2
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    # Wait 2 days after a release before opening a PR, to skip yanked/broken versions.
-    cooldown:
-      default-days: 2
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -63,8 +60,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 2
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,8 +47,11 @@ updates:
           - "org.objenesis:*"
           - "org.hamcrest:*"
           - "junit:*"
-      # Everything else: bundle only minor/patch so major bumps still arrive as
-      # individual PRs that get reviewed on their own.
+      # Catch-all for dependencies not matched by a named group above: bundle only
+      # minor/patch, so a major bump of an *ungrouped* dependency arrives as its own
+      # PR for individual review. (Majors within a named group are NOT split out —
+      # those groups have no update-types restriction, so e.g. a Jackson or Jetty
+      # major rides along in its group PR.)
       all-minor-and-patch:
         patterns:
           - "*"

--- a/.github/workflows/dependabot-verification-metadata.yaml
+++ b/.github/workflows/dependabot-verification-metadata.yaml
@@ -1,0 +1,60 @@
+name: Dependabot Verification Metadata
+
+# Dependabot cannot update gradle/verification-metadata.xml (dependabot/dependabot-core#1996),
+# so every Gradle bump it pushes would otherwise fail CI on stale checksums. This job
+# regenerates the metadata with a cold cache (per CONTRIBUTING.md) on Dependabot's Gradle
+# branches, validates the build in the same run, and commits the refreshed file back to the PR.
+#
+# Triggering on `push` (not `pull_request`) runs in the base-repo context with a writable
+# token; Dependabot's pull_request runs get a read-only token and cannot push.
+
+on:
+  push:
+    branches:
+      - "dependabot/gradle/**"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-metadata-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          java-package: 'jdk+fx'
+          distribution: 'zulu'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+        with:
+          validate-wrappers: true
+
+      # Cold cache: a warm cache skips re-resolving already-cached parent POMs so they
+      # never get recorded, and the build then fails verification only later in CI.
+      # This step both regenerates the metadata and runs the same build CI runs, so a
+      # green run here proves the bumped artifacts verify and build.
+      - name: Regenerate verification metadata (cold cache)
+        run: |
+          GRADLE_USER_HOME="$(mktemp -d)" ./gradlew --write-verification-metadata sha256 \
+            build dist -PdisableSigning=true -Pcoverage=true
+
+      - name: Commit refreshed metadata
+        run: |
+          if git diff --quiet -- gradle/verification-metadata.xml; then
+            echo "No verification metadata changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Regenerate Gradle dependency verification metadata" \
+            -- gradle/verification-metadata.xml
+          git push origin "HEAD:${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary

Adds Dependabot dependency updates for this project, plus a workflow to keep them compatible with the repo's Gradle dependency verification.

- **`.github/dependabot.yml`** — config schema `version: 2`
  - **Ecosystems:** `gradle` (root `/`, covers the multi-module build via the central `gradle/libs.versions.toml` catalog) and `docker` (the root `Dockerfile`)
  - **Schedule:** `monthly` for both
  - **Grouping:** related artifacts are bundled into one PR, keyed at the *coherent-project* level. `org.apache.*` is deliberately split (`org.apache.commons`, `org.apache.logging.log4j`, …) because it spans unrelated projects (Derby, PDFBox, Velocity, HttpComponents). Groups: `aws-sdk`, `jetty`, `jersey`, `jackson`, `netty`, `log4j`, `apache-commons`, `test-tooling`, and a catch-all `all-minor-and-patch`
  - **Noise controls:** `open-pull-requests-limit` (10 gradle / 5 docker), `labels`, `commit-message` prefixes
- **`.github/workflows/dependabot-verification-metadata.yaml`** — Dependabot cannot update `gradle/verification-metadata.xml` ([dependabot-core#1996](https://github.com/dependabot/dependabot-core/issues/1996)), so its Gradle bumps would fail CI on stale checksums. On `dependabot/gradle/**` branches this workflow regenerates the metadata with a cold cache (per `CONTRIBUTING.md`), validates the build in the same run, and commits the refreshed file back to the PR.

## ⚠️ Manual configuration required (by a repo admin)

These cannot be done from the PR and are needed for the config to behave as described:

1. **Create the labels** (Dependabot only auto-creates its own defaults; custom labels that don't exist are silently dropped, so PRs would arrive unlabeled):
   ```sh
   gh label create dependencies -c "#0366d6" -d "Dependency updates" --repo OpenIntegrationEngine/engine
   gh label create java         -c "#b07219" -d "Java / Gradle dependencies" --repo OpenIntegrationEngine/engine
   gh label create docker        -c "#1d63ed" -d "Docker base image updates" --repo OpenIntegrationEngine/engine
   ```
2. **Enable Dependabot version updates** for the repo if not already on: *Settings → Code security → Dependabot → Dependency graph + Dependabot version updates.* The config file only governs *how* updates run once the feature is enabled.
3. **Give Actions write permission** so the metadata workflow can push its commit: *Settings → Actions → General → Workflow permissions → "Read and write permissions."*
4. **(Recommended) Make the metadata workflow a required status check** on Dependabot PRs via branch protection. A push made with the default `GITHUB_TOKEN` does not re-trigger `build.yaml`, so the regen workflow is the authoritative green check for Gradle bumps (it runs the full build itself). If you'd rather have `build.yaml` re-run, swap the workflow's push to use a PAT/App token instead of `GITHUB_TOKEN`.

## Notes / follow-ups

- **netty inline pin:** `server/build.gradle` pins `netty-transport-native-epoll` inline with a `linux-x86_64` classifier (the catalog can't express it), so a grouped `netty` bump won't touch that line — watch for drift on the first netty PR.
- A `github-actions` ecosystem entry would be a reasonable follow-up to keep workflow action versions current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)