### PR TITLE
Add a PR template with a required "How to verify" section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing! See CONTRIBUTING.md. Keep this PR to one concern; open large or
+sweeping changes as an issue first so scope and a verification plan can be agreed.
+-->
+
+## What & why
+<!-- What does this change do, and why? -->
+
+Closes #<!-- issue number (required; no PR without a referenced issue) -->
+
+## How to verify
+<!--
+REQUIRED for any behavior change. Give a reviewer a runnable before/after — not just "tests pass."
+Replacing the battery isn't the job; starting the car is.
+
+- Exact steps / input to reproduce.
+- Observable result BEFORE this change (the bug) vs AFTER (fixed).
+- For behavior a unit test can't capture (wire output, a deployed channel, a REST path),
+  the exact commands and what you observed.
+
+Docs-only or non-behavioral change? Write "N/A — no behavior change" and why.
+-->
+
+## Checklist
+- [ ] Scoped to one concern; no drive-by reformatting/renames
+- [ ] Tests added/adjusted — a regression test **fails before** the change and **passes after** (line coverage is not proof)
+- [ ] `./gradlew build -PdisableSigning=true -Pcoverage=true` passes locally
+- [ ] Behavior & compatibility preserved (public API, serialization, DB schema, wire/HL7) — or the change is intentional and called out above
+- [ ] No PHI in logs; no new unsafe/reflective deserialization or XXE


### PR DESCRIPTION
## What & why
Adds `.github/PULL_REQUEST_TEMPLATE.md` — the repo had none. Its centerpiece is a required **How to verify** section, so a PR ships with a reviewer-runnable before/after instead of just "tests pass." Short checklist mirrors CONTRIBUTING and the AGENTS.md contributor guardrails (one concern, fail-before/pass-after test, the exact local build command, behavior/compat, no PHI/unsafe-deserialization).

Closes #359. Origin: @pacmano1's request during review of #343 — the mechanic who replaces the battery but never starts the car. Also closes the gap where CONTRIBUTING asks bug *reports* for repro + expected-vs-actual but asks PRs only for "a brief description."

## How to verify
N/A — no runtime/behavior change; this is a GitHub meta file. To confirm it takes effect:
- On this branch the file renders: `.github/PULL_REQUEST_TEMPLATE.md`.
- After merge, opening a new PR pre-fills it (GitHub picks up the template automatically).
- This PR itself follows the template it introduces — references an issue and fills in What/why + this section.

## Checklist
- [x] Scoped to one concern (adds one file)
- [x] N/A — no code/tests (docs/meta)
- [x] N/A — no build impact
- [x] N/A — no behavior/compat surface
- [x] No PHI / deserialization surface
