### PR TITLE
Update renovate configs from maintainer and user feedback

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,20 +47,20 @@
     {
       "groupName": "jetty",
       "matchPackageNames": [
-        "org.eclipse.jetty:*"
+        "org.eclipse.jetty*"
       ]
     },
     {
       "groupName": "bouncycastle",
       "matchPackageNames": [
-        "org.bouncycastle:*"
+        "org.bouncycastle*"
       ]
     },
     {
       "groupName": "jersey",
       "matchPackageNames": [
-        "org.glassfish.jersey:*",
-        "org.glassfish.hk2:*"
+        "org.glassfish.jersey*",
+        "org.glassfish.hk2*"
       ]
     },
     {
@@ -72,26 +72,26 @@
     {
       "groupName": "sun-xml",
       "matchPackageNames": [
-        "com.sun.xml:*"
+        "com.sun.xml*"
       ]
     },
     {
       "groupName": "jackson",
       "matchPackageNames": [
-        "com.fasterxml.jackson:*"
+        "com.fasterxml.jackson*"
       ]
     },
     {
       "groupName": "netty",
       "matchPackageNames": [
-        "io.netty:*",
-        "com.typesafe.netty:*"
+        "io.netty*",
+        "com.typesafe.netty*"
       ]
     },
     {
       "groupName": "log4j",
       "matchPackageNames": [
-        "org.apache.logging.log4j:*"
+        "org.apache.logging.log4j*"
       ]
     },
     {
@@ -104,8 +104,8 @@
     {
       "groupName": "test-tooling",
       "matchPackageNames": [
-        "org.mockito:*",
-        "net.bytebuddy:*",
+        "org.mockito:",
+        "net.bytebuddy*",
         "org.objenesis:*",
         "org.hamcrest:*",
         "junit:*"

--- a/renovate.json
+++ b/renovate.json
@@ -39,14 +39,6 @@
       ]
     },
     {
-      "description": "Catch-all: bundle minor/patch of ungrouped deps; majors stay individual. Listed BEFORE the named groups so a family's own minor/patch is overridden back into its family group (Renovate merges rules, last match wins for groupName).",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all-minor-and-patch"
-    },
-    {
       "groupName": "aws-sdk",
       "matchPackageNames": [
         "software.amazon.awssdk:*",
@@ -56,33 +48,51 @@
     {
       "groupName": "jetty",
       "matchPackageNames": [
-        "org.eclipse.jetty*"
+        "org.eclipse.jetty:*"
+      ]
+    },
+    {
+      "groupName": "bouncycastle",
+      "matchPackageNames": [
+        "org.bouncycastle:*"
       ]
     },
     {
       "groupName": "jersey",
       "matchPackageNames": [
-        "org.glassfish.jersey*",
-        "org.glassfish.hk2*"
+        "org.glassfish.jersey:*",
+        "org.glassfish.hk2:*"
+      ]
+    },
+    {
+      "groupName": "pdfbox",
+      "matchPackageNames": [
+        "*pdfbox*"
+      ]
+    },
+    {
+      "groupName": "sun-xml",
+      "matchPackageNames": [
+        "com.sun.xml:*"
       ]
     },
     {
       "groupName": "jackson",
       "matchPackageNames": [
-        "com.fasterxml.jackson*"
+        "com.fasterxml.jackson:*"
       ]
     },
     {
       "groupName": "netty",
       "matchPackageNames": [
-        "io.netty*",
-        "com.typesafe.netty*"
+        "io.netty:*",
+        "com.typesafe.netty:*"
       ]
     },
     {
       "groupName": "log4j",
       "matchPackageNames": [
-        "org.apache.logging.log4j*"
+        "org.apache.logging.log4j:*"
       ]
     },
     {
@@ -95,8 +105,8 @@
     {
       "groupName": "test-tooling",
       "matchPackageNames": [
-        "org.mockito*",
-        "net.bytebuddy*",
+        "org.mockito:*",
+        "net.bytebuddy:*",
         "org.objenesis:*",
         "org.hamcrest:*",
         "junit:*"

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "schedule": [
-    "before 6am on the first day of the month"
+    "monthly"
   ],
   "timezone": "America/New_York",
   "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "schedule": [
-    "monthly"
+    "config:recommended",
+    "schedule:monthly"
   ],
   "timezone": "America/New_York",
   "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -104,7 +104,7 @@
     {
       "groupName": "test-tooling",
       "matchPackageNames": [
-        "org.mockito:",
+        "org.mockito*",
         "net.bytebuddy*",
         "org.objenesis:*",
         "org.hamcrest:*",

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
   "automerge": false,
+  "rebaseWhen": "conflicted",
   "major": {
     "dependencyDashboardApproval": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "before 6am on the first day of the month"
   ],
   "timezone": "America/New_York",
-  "minimumReleaseAge": "2 days",
+  "minimumReleaseAge": "14 days",
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
   "automerge": false,


### PR DESCRIPTION
Fixes to address comments from users and maintainers on Renvoate bot.

https://github.com/renovatebot/renovate/discussions/35165 I think this is key. We reference reccomended presets but I think some of those generate behaviors that are undesirable to OIE. 

This PR was done by human hands and eyes, no clankers. I read https://docs.renovatebot.com/configuration-options/ and took the comments from maintainers and users in Discord. 

Grouping _is_ working but renovate submits security patches separately. 

The all-minor-and-patch rule needs to go. Theres like 50 packages in there. Thats not what we want. It bundles all those minor updates into one massive set. Pauls clanker called this out as non-blocking in PR #358 but I think it is a problem. Thats one big-big PR.

> If you're tweaking, I think the 2-day cooldown is too short, and something like 7-14 would be more appropriate for non-security patches. We don't move that quickly, and with it only checking once a month, anyway, we don't need it bringing in patches that fresh.

I can do days, but I do not think I can distinguish between security updates and other updates. This PR sets it to 14 days. I think security always gets pushed. See next topic.

> I know when I was looking, there is also a way to limit the number of PRs it has opened at one time, so that we don't get overwhelmed with them.

We have this. Its set to 10, but per Renvoate docs:
> Renovate always creates security PRs, even if the concurrent PR limit is already reached. Security PRs have [SECURITY] in their PR title.

The batch from PR #358 was entirely security updates. Renovate has many held updates that are non-security. These are visible at https://developer.mend.io/


Screenshot shows the ugly `all-minor-and-patch` behavior. It also shows groups working for non-security updates.
<img width="1134" height="415" alt="image" src="https://github.com/user-attachments/assets/9287d40f-71d7-4f09-9902-fad3deffa1b6" />
