### PR TITLE
Avoid keystore errors by restoring the clean-appdata-on-build behavior

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -538,6 +538,7 @@ def stageSetup = tasks.register('stageSetup') {
               ':command:writeArtifactInventory'
     outputs.upToDateWhen { false }
     doLast {
+        project.delete('setup/appdata')
         ['conf', 'extensions', 'public_html', 'public_api_html', 'server-lib', 'client-lib',
          'cli-lib', 'logs', 'docs', 'server-launcher-lib'].each { file("setup/${it}").mkdirs() }
 


### PR DESCRIPTION
Ant used to clear appdata on build.  Without that, the following errors occur when starting the server during development after multiple build-run cycles:

<blockquote>
ERROR 2026-07-25 18:02:21.925 [Main Server Thread] com.mirth.connect.server.controllers.DefaultConfigurationController: Could not initialize security settings.
java.io.IOException: Keystore was tampered with, or password was incorrect
        at java.base/com.sun.crypto.provider.JceKeyStore.engineLoad(JceKeyStore.java:882)
        at java.base/java.security.KeyStore.load(KeyStore.java:1473)
        at com.mirth.connect.server.controllers.DefaultConfigurationController.initializeSecuritySettings(DefaultConfigurationController.java:1239)
        at com.mirth.connect.server.Mirth.startup(Mirth.java:221)
        at com.mirth.connect.server.Mirth.run(Mirth.java:169)
Caused by: java.security.UnrecoverableKeyException: Password verification failed
        ... 5 more
</blockquote>

This PR restores the historical behavior.