### PR TITLE
Add configurable request header size to the HTTP Listener

### DIFF
--- a/client/src/main/java/com/mirth/connect/connectors/http/HttpListener.java
+++ b/client/src/main/java/com/mirth/connect/connectors/http/HttpListener.java
@@ -53,6 +53,7 @@ import net.miginfocom.swing.MigLayout;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.entity.ContentType;
 import org.jdesktop.swingx.decorator.Highlighter;
 import org.jdesktop.swingx.decorator.HighlighterFactory;
@@ -142,6 +143,7 @@ public class HttpListener extends ConnectorSettingsPanel {
         HttpReceiverProperties properties = (HttpReceiverProperties) getDefaults();
         properties.setContextPath(contextPathField.getText());
         properties.setTimeout(receiveTimeoutField.getText());
+        properties.setRequestHeaderSize(requestHeaderSizeField.getText());
         properties.setXmlBody(messageContentXmlBodyRadio.isSelected());
         properties.setParseMultipart(parseMultipartYesRadio.isSelected());
         properties.setIncludeMetadata(includeMetadataYesRadio.isSelected());
@@ -168,6 +170,7 @@ public class HttpListener extends ConnectorSettingsPanel {
 
         contextPathField.setText(props.getContextPath());
         receiveTimeoutField.setText(props.getTimeout());
+        requestHeaderSizeField.setText(props.getRequestHeaderSize());
 
         updateHttpUrl();
 
@@ -247,6 +250,19 @@ public class HttpListener extends ConnectorSettingsPanel {
             }
         }
 
+        /*
+         * A template is resolved when the channel starts, so only a plain value can be checked here.
+         * A non-positive size is worth catching because Jetty treats it as no limit at all, which
+         * silently removes the header cap rather than failing visibly.
+         */
+        String requestHeaderSize = props.getRequestHeaderSize();
+        if (!requestHeaderSize.contains("$") && NumberUtils.toInt(requestHeaderSize, 0) <= 0) {
+            valid = false;
+            if (highlight) {
+                requestHeaderSizeField.setBackground(UIConstants.INVALID_COLOR);
+            }
+        }
+
         if (!props.getSourceConnectorProperties().getResponseVariable().equalsIgnoreCase("None")) {
             if (props.getResponseContentType().length() == 0) {
                 valid = false;
@@ -269,6 +285,7 @@ public class HttpListener extends ConnectorSettingsPanel {
     @Override
     public void resetInvalidProperties() {
         receiveTimeoutField.setBackground(null);
+        requestHeaderSizeField.setBackground(null);
         responseContentTypeField.setBackground(null);
         responseHeadersVariableField.setBackground(null);
     }
@@ -841,6 +858,8 @@ public class HttpListener extends ConnectorSettingsPanel {
         contextPathField = new MirthTextField();
         receiveTimeoutLabel = new JLabel();
         receiveTimeoutField = new MirthTextField();
+        requestHeaderSizeLabel = new JLabel();
+        requestHeaderSizeField = new MirthTextField();
         httpUrlField = new JTextField();
         httpUrlLabel = new JLabel();
         headersLabel = new JLabel();
@@ -900,6 +919,8 @@ public class HttpListener extends ConnectorSettingsPanel {
         });
 
         receiveTimeoutLabel.setText("Receive Timeout (ms):");
+
+        requestHeaderSizeLabel.setText("Request Header Size (bytes):");
 
         httpUrlLabel.setText("HTTP URL:");
 
@@ -1042,6 +1063,7 @@ public class HttpListener extends ConnectorSettingsPanel {
         charsetEncodingCombobox.setToolTipText(String.format("<html>Select the character set encoding to be used for the response to the sending system.<br>Set to Default to assume the default character set encoding for the JVM running %s.</html>", BrandingConstants.PRODUCT_NAME));
         contextPathField.setToolTipText("The context path for the HTTP Listener URL.");
         receiveTimeoutField.setToolTipText("Enter the maximum idle time in milliseconds for a connection.");
+        requestHeaderSizeField.setToolTipText("<html>The maximum combined size in bytes of all request headers.<br/>Requests larger than this are rejected with 431 Request Header Fields<br/>Too Large before the channel sees them. The default is 8192.<br/>The value may include template substitutions, and must resolve to a number.</html>");
         httpUrlField.setToolTipText("<html>Displays the generated HTTP URL for the HTTP Listener.</html>");
         responseHeadersTable.setToolTipText("Response header parameters are encoded as HTTP headers in the response sent to the client.");
         responseStatusCodeField.setToolTipText("<html>Enter the status code for the HTTP response.  If this field is left blank a <br>default status code of 200 will be returned for a successful message, <br>and 500 will be returned for an errored message. If a \"Respond from\" <br>value is chosen, that response will be used to determine a successful <br>or errored response.<html>");
@@ -1061,12 +1083,14 @@ public class HttpListener extends ConnectorSettingsPanel {
     }
 
     protected void initLayout() {
-        setLayout(new MigLayout("insets 0 8 0 8, novisualpadding, hidemode 3, gap 12 6", "[][]6[]", "[][][][][][][][][][][][][grow][grow]"));
+        setLayout(new MigLayout("insets 0 8 0 8, novisualpadding, hidemode 3, gap 12 6", "[][]6[]", "[][][][][][][][][][][][][][grow][grow]"));
 
         add(contextPathLabel, "right");
         add(contextPathField, "w 150!, sx");
         add(receiveTimeoutLabel, "newline, right");
         add(receiveTimeoutField, "w 100!, sx");
+        add(requestHeaderSizeLabel, "newline, right");
+        add(requestHeaderSizeField, "w 100!, sx");
         add(messageContentLabel, "newline, right");
         add(messageContentPlainBodyRadio, "split 2");
         add(messageContentXmlBodyRadio);
@@ -1229,6 +1253,8 @@ public class HttpListener extends ConnectorSettingsPanel {
     private MirthRadioButton parseMultipartYesRadio;
     protected MirthTextField receiveTimeoutField;
     protected JLabel receiveTimeoutLabel;
+    protected MirthTextField requestHeaderSizeField;
+    protected JLabel requestHeaderSizeLabel;
     protected JLabel responseStatusCodeLabel;
     private MirthTextField responseContentTypeField;
     private JLabel responseContentTypeLabel;

--- a/server/src/main/java/com/mirth/connect/connectors/http/DefaultHttpConfiguration.java
+++ b/server/src/main/java/com/mirth/connect/connectors/http/DefaultHttpConfiguration.java
@@ -47,7 +47,8 @@ public class DefaultHttpConfiguration implements HttpConfiguration {
         org.eclipse.jetty.server.HttpConfiguration httpConfig = new org.eclipse.jetty.server.HttpConfiguration();
         httpConfig.setSendServerVersion(false);
         httpConfig.setSendXPoweredBy(false);
-        
+        httpConfig.setRequestHeaderSize(connector.getRequestHeaderSize());
+
         ServerConnector listener = new ServerConnector(connector.getServer(), new HttpConnectionFactory(httpConfig));
         listener.setHost(connector.getHost());
         listener.setPort(connector.getPort());

--- a/server/src/main/java/com/mirth/connect/connectors/http/DefaultHttpConfiguration.java
+++ b/server/src/main/java/com/mirth/connect/connectors/http/DefaultHttpConfiguration.java
@@ -44,16 +44,24 @@ public class DefaultHttpConfiguration implements HttpConfiguration {
 
     @Override
     public void configureReceiver(HttpReceiver connector) throws Exception {
-        org.eclipse.jetty.server.HttpConfiguration httpConfig = new org.eclipse.jetty.server.HttpConfiguration();
-        httpConfig.setSendServerVersion(false);
-        httpConfig.setSendXPoweredBy(false);
-        httpConfig.setRequestHeaderSize(connector.getRequestHeaderSize());
-
-        ServerConnector listener = new ServerConnector(connector.getServer(), new HttpConnectionFactory(httpConfig));
+        ServerConnector listener = new ServerConnector(connector.getServer(), new HttpConnectionFactory(createHttpConfig(connector)));
         listener.setHost(connector.getHost());
         listener.setPort(connector.getPort());
         listener.setIdleTimeout(connector.getTimeout());
         connector.getServer().addConnector(listener);
+    }
+
+    /**
+     * Builds the Jetty configuration the listener is created with. An implementation that overrides
+     * {@link #configureReceiver(HttpReceiver)} should build its own listener from this rather than
+     * repeating the settings, so that it keeps up with changes to the defaults.
+     */
+    protected org.eclipse.jetty.server.HttpConfiguration createHttpConfig(HttpReceiver connector) {
+        org.eclipse.jetty.server.HttpConfiguration httpConfig = new org.eclipse.jetty.server.HttpConfiguration();
+        httpConfig.setSendServerVersion(false);
+        httpConfig.setSendXPoweredBy(false);
+        httpConfig.setRequestHeaderSize(connector.getRequestHeaderSize());
+        return httpConfig;
     }
 
     @Override

--- a/server/src/main/java/com/mirth/connect/connectors/http/HttpReceiver.java
+++ b/server/src/main/java/com/mirth/connect/connectors/http/HttpReceiver.java
@@ -130,6 +130,7 @@ public class HttpReceiver extends SourceConnector implements BinaryContentTypeRe
     private String host;
     private int port;
     private int timeout;
+    private int requestHeaderSize;
     private String[] binaryMimeTypesArray;
     private Pattern binaryMimeTypesRegex;
     private HttpAuthConnectorPluginProperties authProps;
@@ -201,6 +202,16 @@ public class HttpReceiver extends SourceConnector implements BinaryContentTypeRe
         host = replacer.replaceValues(getConnectorProperties().getListenerConnectorProperties().getHost(), channelId, channelName);
         port = NumberUtils.toInt(replacer.replaceValues(getConnectorProperties().getListenerConnectorProperties().getPort(), channelId, channelName));
         timeout = NumberUtils.toInt(replacer.replaceValues(getConnectorProperties().getTimeout(), channelId, channelName), 0);
+        requestHeaderSize = NumberUtils.toInt(replacer.replaceValues(getConnectorProperties().getRequestHeaderSize(), channelId, channelName), HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE);
+
+        /*
+         * Jetty treats a non-positive request header size as no limit at all, so a channel deployed
+         * with one would silently lose the header cap. The connector panel rejects those values, but
+         * a channel imported or pushed through the API never runs that check.
+         */
+        if (requestHeaderSize <= 0) {
+            requestHeaderSize = HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE;
+        }
 
         // Initialize contextPath to "" or its value after replacements
         String contextPath = (getConnectorProperties().getContextPath() == null ? "" : replacer.replaceValues(getConnectorProperties().getContextPath(), channelId, channelName)).trim();
@@ -837,6 +848,10 @@ public class HttpReceiver extends SourceConnector implements BinaryContentTypeRe
 
     public int getTimeout() {
         return timeout;
+    }
+
+    public int getRequestHeaderSize() {
+        return requestHeaderSize;
     }
 
     protected Map<String, List<String>> extractParameters(Request request) {

--- a/server/src/main/java/com/mirth/connect/connectors/http/HttpReceiver.java
+++ b/server/src/main/java/com/mirth/connect/connectors/http/HttpReceiver.java
@@ -202,15 +202,19 @@ public class HttpReceiver extends SourceConnector implements BinaryContentTypeRe
         host = replacer.replaceValues(getConnectorProperties().getListenerConnectorProperties().getHost(), channelId, channelName);
         port = NumberUtils.toInt(replacer.replaceValues(getConnectorProperties().getListenerConnectorProperties().getPort(), channelId, channelName));
         timeout = NumberUtils.toInt(replacer.replaceValues(getConnectorProperties().getTimeout(), channelId, channelName), 0);
-        requestHeaderSize = NumberUtils.toInt(replacer.replaceValues(getConnectorProperties().getRequestHeaderSize(), channelId, channelName), HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE);
 
         /*
-         * Jetty treats a non-positive request header size as no limit at all, so a channel deployed
-         * with one would silently lose the header cap. The connector panel rejects those values, but
+         * A request header size that does not resolve to a positive number fails the connector
+         * rather than falling back to the default. Jetty treats a non-positive size as no limit at
+         * all, and a value that cannot be parsed would quietly restore a cap the user was trying to
+         * lower, so both cases are a silent loss of the limit. The connector panel rejects them, but
          * a channel imported or pushed through the API never runs that check.
          */
+        String requestHeaderSizeValue = replacer.replaceValues(getConnectorProperties().getRequestHeaderSize(), channelId, channelName);
+        requestHeaderSize = NumberUtils.toInt(requestHeaderSizeValue, 0);
+
         if (requestHeaderSize <= 0) {
-            requestHeaderSize = HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE;
+            throw new ConnectorTaskException("Invalid request header size: " + requestHeaderSizeValue);
         }
 
         // Initialize contextPath to "" or its value after replacements

--- a/server/src/main/java/com/mirth/connect/connectors/http/HttpReceiverProperties.java
+++ b/server/src/main/java/com/mirth/connect/connectors/http/HttpReceiverProperties.java
@@ -25,6 +25,13 @@ import com.mirth.connect.donkey.util.DonkeyElement;
 import com.mirth.connect.donkey.util.purge.PurgeUtil;
 
 public class HttpReceiverProperties extends ConnectorProperties implements ListenerConnectorPropertiesInterface, SourceConnectorPropertiesInterface {
+    /**
+     * Jetty's own default for HttpConfiguration.setRequestHeaderSize. Channels saved before this
+     * property existed have no requestHeaderSize element, so the getter falls back to this and
+     * their behavior is unchanged.
+     */
+    public static final int DEFAULT_REQUEST_HEADER_SIZE = 8192;
+
     private ListenerConnectorProperties listenerConnectorProperties;
     private SourceConnectorProperties sourceConnectorProperties;
 
@@ -42,6 +49,7 @@ public class HttpReceiverProperties extends ConnectorProperties implements Liste
     private String charset;
     private String contextPath;
     private String timeout;
+    private String requestHeaderSize;
     private List<HttpStaticResource> staticResources;
 
     public HttpReceiverProperties() {
@@ -60,6 +68,7 @@ public class HttpReceiverProperties extends ConnectorProperties implements Liste
         this.charset = "UTF-8";
         this.contextPath = "";
         this.timeout = "30000";
+        this.requestHeaderSize = String.valueOf(DEFAULT_REQUEST_HEADER_SIZE);
         this.staticResources = new ArrayList<HttpStaticResource>();
         this.responseHeadersVariable = "";
         this.useResponseHeadersVariable = false;
@@ -177,6 +186,14 @@ public class HttpReceiverProperties extends ConnectorProperties implements Liste
         this.timeout = timeout;
     }
 
+    public String getRequestHeaderSize() {
+        return requestHeaderSize == null ? String.valueOf(DEFAULT_REQUEST_HEADER_SIZE) : requestHeaderSize;
+    }
+
+    public void setRequestHeaderSize(String requestHeaderSize) {
+        this.requestHeaderSize = requestHeaderSize;
+    }
+
     public List<HttpStaticResource> getStaticResources() {
         return staticResources;
     }
@@ -287,6 +304,7 @@ public class HttpReceiverProperties extends ConnectorProperties implements Liste
         purgedProperties.put("responseHeaderChars", responseHeaders.size());
         purgedProperties.put("charset", charset);
         purgedProperties.put("timeout", PurgeUtil.getNumericValue(timeout));
+        purgedProperties.put("requestHeaderSize", PurgeUtil.getNumericValue(getRequestHeaderSize()));
         return purgedProperties;
     }
 }

--- a/server/src/test/java/com/mirth/connect/connectors/http/DefaultHttpConfigurationTest.java
+++ b/server/src/test/java/com/mirth/connect/connectors/http/DefaultHttpConfigurationTest.java
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Open Integration Engine
+
+package com.mirth.connect.connectors.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.mirth.connect.server.controllers.ConfigurationController;
+import com.mirth.connect.server.controllers.ControllerFactory;
+
+/**
+ * Exercises the request header size setting against a real Jetty connector, since the whole point
+ * of the property is behavior Jetty enforces before any channel code runs.
+ */
+public class DefaultHttpConfigurationTest {
+
+    private static final int LARGE_HEADER_BYTES = 16384;
+
+    private Server server;
+
+    @BeforeClass
+    public static void setupBeforeClass() {
+        ControllerFactory controllerFactory = mock(ControllerFactory.class);
+        when(controllerFactory.createConfigurationController()).thenReturn(mock(ConfigurationController.class));
+
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                requestStaticInjection(ControllerFactory.class);
+                bind(ControllerFactory.class).toInstance(controllerFactory);
+            }
+        });
+        injector.getInstance(ControllerFactory.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+            server = null;
+        }
+    }
+
+    @Test
+    public void testJettyDefaultRejectsOversizedHeader() throws Exception {
+        assertEquals(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE_431, sendLargeHeaderRequest(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE));
+    }
+
+    @Test
+    public void testRaisedRequestHeaderSizeAcceptsOversizedHeader() throws Exception {
+        assertEquals(HttpStatus.OK_200, sendLargeHeaderRequest(65536));
+    }
+
+    private int sendLargeHeaderRequest(int requestHeaderSize) throws Exception {
+        int port = startReceiver(requestHeaderSize);
+
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet("http://127.0.0.1:" + port + "/");
+            get.addHeader("X-Large-Header", StringUtils.repeat('a', LARGE_HEADER_BYTES));
+
+            try (CloseableHttpResponse response = client.execute(get)) {
+                return response.getStatusLine().getStatusCode();
+            }
+        }
+    }
+
+    private int startReceiver(int requestHeaderSize) throws Exception {
+        server = new Server();
+
+        HttpReceiver receiver = mock(HttpReceiver.class);
+        when(receiver.getServer()).thenReturn(server);
+        when(receiver.getHost()).thenReturn("127.0.0.1");
+        when(receiver.getPort()).thenReturn(0);
+        when(receiver.getTimeout()).thenReturn(30000);
+        when(receiver.getRequestHeaderSize()).thenReturn(requestHeaderSize);
+
+        new DefaultHttpConfiguration().configureReceiver(receiver);
+
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+                baseRequest.setHandled(true);
+                response.setStatus(HttpServletResponse.SC_OK);
+            }
+        });
+
+        server.start();
+        return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+    }
+}

--- a/server/src/test/java/com/mirth/connect/connectors/http/HttpReceiverPropertiesTest.java
+++ b/server/src/test/java/com/mirth/connect/connectors/http/HttpReceiverPropertiesTest.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Open Integration Engine
+
+package com.mirth.connect.connectors.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.mirth.connect.client.core.Version;
+import com.mirth.connect.model.converters.ObjectXMLSerializer;
+
+public class HttpReceiverPropertiesTest {
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        try {
+            ObjectXMLSerializer.getInstance().init(Version.getLatest().toString());
+        } catch (Exception e) {
+            // Ignore if it has already been initialized
+        }
+    }
+
+    /**
+     * The whole point of the constant is that leaving the field alone changes nothing, so it has to
+     * track Jetty rather than merely agree with itself. This fails if a Jetty upgrade moves the
+     * default out from under us.
+     */
+    @Test
+    public void testDefaultRequestHeaderSizeMatchesJetty() {
+        assertEquals(new org.eclipse.jetty.server.HttpConfiguration().getRequestHeaderSize(), HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE);
+    }
+
+    @Test
+    public void testNewPropertiesUseTheDefaultRequestHeaderSize() {
+        assertEquals(String.valueOf(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE), new HttpReceiverProperties().getRequestHeaderSize());
+    }
+
+    @Test
+    public void testRequestHeaderSizeRoundTrip() {
+        HttpReceiverProperties properties = new HttpReceiverProperties();
+        properties.setRequestHeaderSize("32768");
+        assertEquals("32768", properties.getRequestHeaderSize());
+    }
+
+    /**
+     * Channels saved before this property existed have no requestHeaderSize element. XStream
+     * instantiates without calling the constructor, so the field stays null and the getter is the
+     * only thing standing between an old channel and a listener configured with a header size of
+     * zero.
+     */
+    @Test
+    public void testPropertiesWithoutRequestHeaderSizeElementFallBackToJettyDefault() {
+        HttpReceiverProperties properties = new HttpReceiverProperties();
+        properties.setRequestHeaderSize("32768");
+
+        String xml = ObjectXMLSerializer.getInstance().serialize(properties);
+        String legacyXml = xml.replaceAll("<requestHeaderSize>[^<]*</requestHeaderSize>", "");
+        assertFalse(legacyXml.contains("requestHeaderSize"));
+
+        HttpReceiverProperties deserialized = ObjectXMLSerializer.getInstance().deserialize(legacyXml, HttpReceiverProperties.class);
+        assertEquals(String.valueOf(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE), deserialized.getRequestHeaderSize());
+    }
+}

--- a/server/src/test/java/com/mirth/connect/connectors/http/HttpReceiverRequestHeaderSizeTest.java
+++ b/server/src/test/java/com/mirth/connect/connectors/http/HttpReceiverRequestHeaderSizeTest.java
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Open Integration Engine
+
+package com.mirth.connect.connectors.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.mirth.connect.donkey.server.channel.Channel;
+import com.mirth.connect.donkey.server.event.EventDispatcher;
+import com.mirth.connect.server.controllers.ConfigurationController;
+import com.mirth.connect.server.controllers.ControllerFactory;
+import com.mirth.connect.server.controllers.EventController;
+
+/**
+ * Covers what HttpReceiver.onStart() does to the configured request header size before Jetty ever
+ * sees it: template resolution, the fallback for values that cannot be parsed, and the clamp that
+ * keeps a non-positive value from silently removing the header limit.
+ */
+public class HttpReceiverRequestHeaderSizeTest {
+
+    private static final String TEST_CHANNEL_ID = UUID.randomUUID().toString();
+    private static final String TEST_CHANNEL_NAME = "Test HTTP Listener Channel";
+
+    private HttpReceiver receiver;
+
+    @BeforeClass
+    public static void setupBeforeClass() {
+        ControllerFactory controllerFactory = mock(ControllerFactory.class);
+        when(controllerFactory.createConfigurationController()).thenReturn(mock(ConfigurationController.class));
+        when(controllerFactory.createEventController()).thenReturn(mock(EventController.class));
+
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                requestStaticInjection(ControllerFactory.class);
+                bind(ControllerFactory.class).toInstance(controllerFactory);
+            }
+        });
+        injector.getInstance(ControllerFactory.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (receiver != null) {
+            receiver.stop();
+            receiver.onUndeploy();
+            receiver = null;
+        }
+    }
+
+    @Test
+    public void testConfiguredValueIsUsed() throws Exception {
+        assertEquals(32768, startWith("32768"));
+    }
+
+    @Test
+    public void testMissingValueFallsBackToJettyDefault() throws Exception {
+        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith(null));
+    }
+
+    @Test
+    public void testUnparseableValueFallsBackToJettyDefault() throws Exception {
+        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("not a number"));
+    }
+
+    /**
+     * An unresolved template arrives at NumberUtils as the literal ${...} text, so it has to land on
+     * the default rather than zero.
+     */
+    @Test
+    public void testUnresolvedTemplateFallsBackToJettyDefault() throws Exception {
+        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("${nothingDefinesThis}"));
+    }
+
+    /**
+     * Jetty treats a non-positive request header size as no limit at all. The connector panel rejects
+     * those values, but a channel imported or pushed through the REST API never runs that check, so
+     * the receiver has to clamp them itself.
+     */
+    @Test
+    public void testZeroIsClampedToJettyDefault() throws Exception {
+        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("0"));
+    }
+
+    @Test
+    public void testNegativeIsClampedToJettyDefault() throws Exception {
+        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("-1"));
+    }
+
+    private int startWith(String requestHeaderSize) throws Exception {
+        HttpReceiverProperties properties = new HttpReceiverProperties();
+        properties.getListenerConnectorProperties().setHost("127.0.0.1");
+        properties.getListenerConnectorProperties().setPort("0");
+        properties.setRequestHeaderSize(requestHeaderSize);
+
+        receiver = new TestHttpReceiver(properties);
+
+        Channel channel = new TestChannel();
+        channel.setChannelId(TEST_CHANNEL_ID);
+        channel.setName(TEST_CHANNEL_NAME);
+        receiver.setChannel(channel);
+
+        receiver.onDeploy();
+        receiver.start();
+
+        return receiver.getRequestHeaderSize();
+    }
+
+    private static class TestHttpReceiver extends HttpReceiver {
+
+        public TestHttpReceiver(HttpReceiverProperties properties) {
+            super();
+            setChannelId(TEST_CHANNEL_ID);
+            setMetaDataId(0);
+            setConnectorProperties(properties);
+        }
+
+        @Override
+        protected String getConfigurationClass() {
+            return DefaultHttpConfiguration.class.getName();
+        }
+    }
+
+    private static class TestChannel extends Channel {
+
+        @Override
+        protected EventDispatcher getEventDispatcher() {
+            return mock(EventDispatcher.class);
+        }
+    }
+}

--- a/server/src/test/java/com/mirth/connect/connectors/http/HttpReceiverRequestHeaderSizeTest.java
+++ b/server/src/test/java/com/mirth/connect/connectors/http/HttpReceiverRequestHeaderSizeTest.java
@@ -4,6 +4,8 @@
 package com.mirth.connect.connectors.http;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +18,7 @@ import org.junit.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.mirth.connect.donkey.server.ConnectorTaskException;
 import com.mirth.connect.donkey.server.channel.Channel;
 import com.mirth.connect.donkey.server.event.EventDispatcher;
 import com.mirth.connect.server.controllers.ConfigurationController;
@@ -23,9 +26,9 @@ import com.mirth.connect.server.controllers.ControllerFactory;
 import com.mirth.connect.server.controllers.EventController;
 
 /**
- * Covers what HttpReceiver.onStart() does to the configured request header size before Jetty ever
- * sees it: template resolution, the fallback for values that cannot be parsed, and the clamp that
- * keeps a non-positive value from silently removing the header limit.
+ * Covers what HttpReceiver.onStart() does with the configured request header size before Jetty ever
+ * sees it: template resolution, the default applied when nothing is configured, and the failure
+ * raised for anything that does not resolve to a positive number.
  */
 public class HttpReceiverRequestHeaderSizeTest {
 
@@ -69,33 +72,49 @@ public class HttpReceiverRequestHeaderSizeTest {
         assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith(null));
     }
 
+    /**
+     * A value that cannot be parsed would otherwise restore a cap the user was trying to lower, so it
+     * fails the connector rather than falling back.
+     */
     @Test
-    public void testUnparseableValueFallsBackToJettyDefault() throws Exception {
-        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("not a number"));
+    public void testUnparseableValueFailsToStart() throws Exception {
+        assertFailsToStart("not a number");
     }
 
     /**
-     * An unresolved template arrives at NumberUtils as the literal ${...} text, so it has to land on
-     * the default rather than zero.
+     * An unresolved template arrives at NumberUtils as the literal ${...} text. Failing tells the user
+     * their substitution is broken instead of quietly running on the default.
      */
     @Test
-    public void testUnresolvedTemplateFallsBackToJettyDefault() throws Exception {
-        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("${nothingDefinesThis}"));
+    public void testUnresolvedTemplateFailsToStart() throws Exception {
+        assertFailsToStart("${nothingDefinesThis}");
     }
 
     /**
      * Jetty treats a non-positive request header size as no limit at all. The connector panel rejects
-     * those values, but a channel imported or pushed through the REST API never runs that check, so
-     * the receiver has to clamp them itself.
+     * those values, but a channel imported or pushed through the REST API never runs that check.
      */
     @Test
-    public void testZeroIsClampedToJettyDefault() throws Exception {
-        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("0"));
+    public void testZeroFailsToStart() throws Exception {
+        assertFailsToStart("0");
     }
 
     @Test
-    public void testNegativeIsClampedToJettyDefault() throws Exception {
-        assertEquals(HttpReceiverProperties.DEFAULT_REQUEST_HEADER_SIZE, startWith("-1"));
+    public void testNegativeFailsToStart() throws Exception {
+        assertFailsToStart("-1");
+    }
+
+    /**
+     * Asserts the connector refuses to start and that the message carries the value as it resolved, so
+     * the cause is visible without reading the channel configuration.
+     */
+    private void assertFailsToStart(String requestHeaderSize) throws Exception {
+        try {
+            startWith(requestHeaderSize);
+            fail("Expected ConnectorTaskException for request header size \"" + requestHeaderSize + "\"");
+        } catch (ConnectorTaskException e) {
+            assertTrue("Message should contain the resolved value but was: " + e.getMessage(), e.getMessage().contains(requestHeaderSize));
+        }
     }
 
     private int startWith(String requestHeaderSize) throws Exception {


### PR DESCRIPTION
Closes #392.

Jetty caps the combined size of all request headers at 8192 bytes and answers anything larger with `431 Request Header Fields Too Large` during header parsing, so the channel never sees the request. This adds a per-connector **Request Header Size** field.

The value is a String and resolves through the template replacer at channel start, like `host`, `port` and `timeout` already do.

## Invalid values fail the connector

Addressing @mgaffigan's review. A value that does not resolve to a positive number now fails the connector at start rather than falling back to 8192:

```java
String requestHeaderSizeValue = replacer.replaceValues(getConnectorProperties().getRequestHeaderSize(), channelId, channelName);
requestHeaderSize = NumberUtils.toInt(requestHeaderSizeValue, 0);

if (requestHeaderSize <= 0) {
    throw new ConnectorTaskException("Invalid request header size: " + requestHeaderSizeValue);
}
```

Falling back was a silent loss of the limit. Someone setting a cap lower than the default, to bound memory use or to stay within what a downstream component expects, would have had the higher default quietly restored.

Passing `0` as the `NumberUtils` default is what makes this one branch instead of two. An unparseable value, an unresolved template, zero and a negative all land on 0 and fail the same way, and the message carries the value as it resolved, so a broken substitution shows up as the literal `${...}` text rather than a number.

Only `requestHeaderSize` changed. The pre-existing `port`, `timeout` and `responseStatusCode` fallbacks in this file have live channels behind them, so tightening those is a separate change.

Addressing @tonygermano's review, the Jetty `HttpConfiguration` is now built in a `protected createHttpConfig(HttpReceiver)` rather than inline in `configureReceiver`. An implementation that overrides `configureReceiver` can build its listener from the current defaults instead of repeating them, and picks up later additions for free. No behaviour change. `TLSHttpConfiguration` in the NovaMap TLS manager plugin extends this class and is the case in point: its non-TLS branch already delegates to `super` and gets the setting, while its TLS branch repeats two of the settings and misses the header size. Raised there as [tls-manager-plugin#44](https://github.com/NovaMap-Health/tls-manager-plugin/issues/44); TLS listeners keep ignoring the setting until that lands.

## Existing channels

Nothing happens to them on upgrade. A channel saved before this feature has no `requestHeaderSize` element, and XStream leaves the field null when it loads one, so `getRequestHeaderSize()` returns 8192 and the channel deploys and runs exactly as it did before. No migration runs and no stored channel is modified.

Open such a channel in the editor and the field shows 8192. That is the getter's answer rather than something read from the channel, so the element is only written the first time someone saves it. Until then an export of that channel still has no element.

The strict check only applies to a value that is actually present, so an absent one can never fail a deploy.

## How to verify

Run on a live engine, HTTP Listener on port 9000, context path `/test`.

| configured value | result |
|---|---|
| `10000` | starts; 9945-byte header returns 200, 9950-byte returns 431 |
| `${headerSize}` with `$gc('headerSize','10000')` in the deploy script | starts; same 9945/9950 boundary, so the resolved value applied rather than the default |
| `0` pushed via the REST API | channel STOPPED, `ConnectorTaskException: Invalid request header size: 0` |
| `${headerSize}` with the deploy script cleared | channel STOPPED, `ConnectorTaskException: Invalid request header size: ${headerSize}` |
| element stripped from the channel XML entirely | starts on 8192, boundary drops accordingly |

The ~55-byte gap between the configured value and the observed boundary is the request line plus `Host`, `User-Agent` and `Accept`.

The last three cannot be reached through the connector panel, which rejects them, so they were pushed through the REST API the way an import or an API-created channel would arrive.

## Tests

12 across three classes: a real Jetty connector for 431 versus 200, a real receiver covering the resolution path including zero, negative, unparseable and an unresolved template, and a serialized-XML round trip proving a channel with no element still gets 8192. Removing the throw fails four tests; changing the default constant fails a third class.

