### PR TITLE
Fix #309: make channelName available in Postprocessor script

### DIFF
--- a/donkey/src/main/java/com/mirth/connect/donkey/model/message/Message.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/model/message/Message.java
@@ -117,6 +117,7 @@ public class Message implements Serializable {
         if (mergedConnectorMessage == null) {
             mergedConnectorMessage = new ConnectorMessage();
             mergedConnectorMessage.setChannelId(channelId);
+            mergedConnectorMessage.setChannelName(channelName);
             mergedConnectorMessage.setMessageId(messageId);
             mergedConnectorMessage.setServerId(serverId);
             mergedConnectorMessage.setReceivedDate(receivedDate);
@@ -128,6 +129,9 @@ public class Message implements Serializable {
             ConnectorMessage sourceConnectorMessage = connectorMessages.get(0);
 
             if (sourceConnectorMessage != null) {
+                if (mergedConnectorMessage.getChannelName() == null) {
+                    mergedConnectorMessage.setChannelName(sourceConnectorMessage.getChannelName());
+                }
                 mergedConnectorMessage.setRaw(sourceConnectorMessage.getRaw());
                 mergedConnectorMessage.setProcessedRaw(sourceConnectorMessage.getProcessedRaw());
                 sourceMap = sourceConnectorMessage.getSourceMap();

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/MessageTest.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/MessageTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ * 
+ * http://www.mirthcorp.com
+ * 
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.donkey.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Calendar;
+
+import org.junit.Test;
+
+import com.mirth.connect.donkey.model.message.ConnectorMessage;
+import com.mirth.connect.donkey.model.message.Message;
+import com.mirth.connect.donkey.model.message.Status;
+
+public class MessageTest {
+
+    private static final String CHANNEL_ID = "test-channel-id";
+    private static final String CHANNEL_NAME = "Test Channel";
+    private static final String SERVER_ID = "test-server-id";
+    private static final long MESSAGE_ID = 1L;
+
+    /**
+     * Regression test for issue #309: the channelName variable was not available in the
+     * Postprocessor script because the merged connector message (used to build the postprocessor
+     * scope) never had its channelName populated.
+     */
+    @Test
+    public void mergedConnectorMessageInheritsChannelNameFromSourceConnectorMessage() {
+        Calendar receivedDate = Calendar.getInstance();
+
+        Message message = new Message();
+        message.setMessageId(MESSAGE_ID);
+        message.setChannelId(CHANNEL_ID);
+        message.setServerId(SERVER_ID);
+        message.setReceivedDate(receivedDate);
+
+        ConnectorMessage sourceConnectorMessage = new ConnectorMessage(CHANNEL_ID, CHANNEL_NAME, MESSAGE_ID, 0, SERVER_ID, receivedDate, Status.RECEIVED);
+        message.getConnectorMessages().put(0, sourceConnectorMessage);
+
+        assertEquals(CHANNEL_NAME, message.getMergedConnectorMessage().getChannelName());
+    }
+
+    /**
+     * When the Message itself carries a channelName, it should be propagated to the merged
+     * connector message even if (theoretically) the source connector message did not have one.
+     */
+    @Test
+    public void mergedConnectorMessageUsesMessageChannelNameWhenSet() {
+        Calendar receivedDate = Calendar.getInstance();
+
+        Message message = new Message();
+        message.setMessageId(MESSAGE_ID);
+        message.setChannelId(CHANNEL_ID);
+        message.setChannelName(CHANNEL_NAME);
+        message.setServerId(SERVER_ID);
+        message.setReceivedDate(receivedDate);
+
+        ConnectorMessage sourceConnectorMessage = new ConnectorMessage(CHANNEL_ID, null, MESSAGE_ID, 0, SERVER_ID, receivedDate, Status.RECEIVED);
+        message.getConnectorMessages().put(0, sourceConnectorMessage);
+
+        assertEquals(CHANNEL_NAME, message.getMergedConnectorMessage().getChannelName());
+    }
+
+    /**
+     * With no channel name available anywhere, the merged connector message channelName stays null
+     * (i.e. the fix does not fabricate a value).
+     */
+    @Test
+    public void mergedConnectorMessageChannelNameNullWhenUnavailable() {
+        Calendar receivedDate = Calendar.getInstance();
+
+        Message message = new Message();
+        message.setMessageId(MESSAGE_ID);
+        message.setChannelId(CHANNEL_ID);
+        message.setServerId(SERVER_ID);
+        message.setReceivedDate(receivedDate);
+
+        ConnectorMessage sourceConnectorMessage = new ConnectorMessage(CHANNEL_ID, null, MESSAGE_ID, 0, SERVER_ID, receivedDate, Status.RECEIVED);
+        message.getConnectorMessages().put(0, sourceConnectorMessage);
+
+        assertNull(message.getMergedConnectorMessage().getChannelName());
+    }
+}

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/MessageTest.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/MessageTest.java
@@ -1,11 +1,5 @@
-/*
- * Copyright (c) Mirth Corporation. All rights reserved.
- * 
- * http://www.mirthcorp.com
- * 
- * The software in this package is published under the terms of the MPL license a copy of which has
- * been included with this distribution in the LICENSE.txt file.
- */
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2026 Giovanni Giannola <giogiannola@globalesm.com>
 
 package com.mirth.connect.donkey.test;
 


### PR DESCRIPTION
## Summary

Fixes #309. The `channelName` variable was not available in Postprocessor scripts, even though it is available in Deploy, Undeploy, and Preprocessor scripts.

## Root cause

The Postprocessor scope (`JavaScriptScopeUtil.getPostprocessorScope`) derives `channelName` from `message.getMergedConnectorMessage().getChannelName()`.

However, `Message.getMergedConnectorMessage()` built the merged `ConnectorMessage` setting `channelId`, `messageId`, `serverId`, and `receivedDate` — but never `channelName`. The value therefore resolved to `null` in Postprocessor scripts.

This also explains why the other script contexts were unaffected: they receive the channel name directly (Deploy/Undeploy via `getDeployScope`/`getUndeployScope`, Preprocessor from the connector message) rather than through the merged connector message.

## Fix

In `Message.getMergedConnectorMessage()`, populate `channelName` on the merged connector message:

- from the `Message`'s own `channelName` field, and
- falling back to the source connector message's `channelName`, which is reliably set during processing (see the `ConnectorMessage` construction in `Channel`).

The fallback matters because the `Message` created during processing does not always carry `channelName`, while the source connector message does.

## Tests

Added `MessageTest` covering three cases:

1. The merged message inherits `channelName` from the source connector message.
2. The merged message uses the `Message`-level `channelName` when set.
3. `channelName` stays `null` when unavailable, so the fix does not fabricate a value.

Verified with `./gradlew :donkey:test`: 21 tests pass, 0 failures (`MessageTest` 3, `StatisticsTest` 9, `JdbcDaoTest` 8, `ChannelTest` 1).
