### PR TITLE
Add configurable channel clone dialog

### DIFF
--- a/client/src/main/java/com/mirth/connect/client/ui/ChannelCloneDialog.java
+++ b/client/src/main/java/com/mirth/connect/client/ui/ChannelCloneDialog.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * The software in this package is published under the terms of the MPL license.
+ */
+
+package com.mirth.connect.client.ui;
+
+import java.awt.Dimension;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+
+import com.mirth.connect.model.Channel;
+import com.mirth.connect.model.ChannelDependency;
+import com.mirth.connect.model.ChannelGroup;
+import com.mirth.connect.model.ChannelTag;
+
+import net.miginfocom.swing.MigLayout;
+import org.apache.commons.lang3.StringUtils;
+
+/** Dialog for selecting which channel associations should be copied during a clone. */
+public class ChannelCloneDialog extends MirthDialog {
+
+    public interface ChannelNameValidator {
+        boolean isValid(String name);
+    }
+
+    public static class Option {
+        private final String id;
+        private final String name;
+
+        public Option(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String toString() {
+            return name == null ? id : name;
+        }
+    }
+
+    private final List<Option> allTags;
+    private final List<Option> allDependencies;
+    private final Set<String> sourceTagIds;
+    private final String sourceId;
+    private final ChannelNameValidator channelNameValidator;
+    private boolean confirmed;
+
+    private JTextField nameField;
+    private JCheckBox pruneCheckBox;
+    private JCheckBox codeTemplateCheckBox;
+    private JCheckBox resourcesCheckBox;
+    private JComboBox<GroupOption> groupComboBox;
+    private DefaultListModel<Option> tagModel;
+    private DefaultListModel<Option> dependencyModel;
+    private JList<Option> tagList;
+    private JList<Option> dependencyList;
+
+    public ChannelCloneDialog(Window owner, Channel channel, Collection<ChannelTag> tags, Collection<ChannelDependency> dependencies,
+            List<GroupOption> groups, String selectedGroupId, boolean hasCodeTemplates, boolean hasResources, ChannelNameValidator channelNameValidator) {
+        super(owner, true);
+        sourceId = channel.getId();
+        this.channelNameValidator = channelNameValidator;
+        allTags = new ArrayList<Option>();
+        allDependencies = new ArrayList<Option>();
+        sourceTagIds = new HashSet<String>();
+
+        for (ChannelTag tag : tags) {
+            allTags.add(new Option(tag.getId(), tag.getName()));
+            if (tag.getChannelIds().contains(sourceId)) {
+                sourceTagIds.add(tag.getId());
+            }
+        }
+
+        for (ChannelDependency dependency : dependencies) {
+            if (sourceId.equals(dependency.getDependentId())) {
+                allDependencies.add(new Option(dependency.getDependencyId(), dependency.getDependencyId()));
+            }
+        }
+
+        initComponents(channel, groups, selectedGroupId, hasCodeTemplates, hasResources);
+        setTitle("Clone channel \"" + channel.getName() + "\"");
+        setPreferredSize(new Dimension(650, 540));
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        pack();
+        setLocationRelativeTo(owner);
+        setVisible(true);
+    }
+
+    private void initComponents(Channel channel, List<GroupOption> groups, String selectedGroupId, boolean hasCodeTemplates, boolean hasResources) {
+        nameField = new JTextField(StringUtils.substring(channel.getName(), 0, 39) + "1");
+        pruneCheckBox = new JCheckBox("Include prune settings", true);
+        codeTemplateCheckBox = new JCheckBox("Include code template libraries", hasCodeTemplates);
+        resourcesCheckBox = new JCheckBox("Include resources", hasResources);
+        groupComboBox = new JComboBox<GroupOption>(new DefaultComboBoxModel<GroupOption>(groups.toArray(new GroupOption[groups.size()])));
+        for (int i = 0; i < groupComboBox.getItemCount(); i++) {
+            if (selectedGroupId != null && selectedGroupId.equals(groupComboBox.getItemAt(i).getId())) {
+                groupComboBox.setSelectedIndex(i);
+                break;
+            }
+        }
+
+        tagModel = new DefaultListModel<Option>();
+        for (Option option : allTags) {
+            if (channelHasTag(channel, option.getId())) {
+                tagModel.addElement(option);
+            }
+        }
+        tagList = createList(tagModel);
+
+        dependencyModel = new DefaultListModel<Option>();
+        for (Option option : allDependencies) {
+            dependencyModel.addElement(option);
+        }
+        dependencyList = createList(dependencyModel);
+
+        JPanel content = new JPanel(new MigLayout("insets 12, fill, wrap 2", "[][grow]", "[]10[]10[]10[grow]10[grow]10[]"));
+        content.add(new JLabel("New Name:"));
+        content.add(nameField, "growx");
+        content.add(pruneCheckBox, "span 2");
+        content.add(new JLabel("Group:"));
+        content.add(groupComboBox, "growx");
+        content.add(new JLabel("Tags:"));
+        content.add(createListPanel(tagList, tagModel, allTags), "grow, push");
+        content.add(new JLabel("Channel Dependencies:"));
+        content.add(createListPanel(dependencyList, dependencyModel, allDependencies), "grow, push");
+        content.add(codeTemplateCheckBox, "span 2");
+        content.add(resourcesCheckBox, "span 2");
+
+        JButton cancelButton = new JButton("Cancel");
+        cancelButton.addActionListener(e -> dispose());
+        JButton okButton = new JButton("OK");
+        okButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String name = nameField.getText().trim();
+                if (name.isEmpty()) {
+                    JOptionPane.showMessageDialog(ChannelCloneDialog.this, "A channel name is required.", "Invalid Name", JOptionPane.WARNING_MESSAGE);
+                    return;
+                }
+                if (channelNameValidator != null && !channelNameValidator.isValid(name)) {
+                    return;
+                }
+                confirmed = true;
+                dispose();
+            }
+        });
+
+        JPanel buttons = new JPanel(new MigLayout("insets 0, right"));
+        buttons.add(cancelButton, "w 80!");
+        buttons.add(okButton, "w 80!");
+        getContentPane().setLayout(new MigLayout("insets 0, fill, wrap"));
+        getContentPane().add(content, "grow, push");
+        getContentPane().add(buttons, "growx");
+    }
+
+    private JList<Option> createList(DefaultListModel<Option> model) {
+        JList<Option> list = new JList<Option>(model);
+        list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        return list;
+    }
+
+    private JPanel createListPanel(JList<Option> list, DefaultListModel<Option> model, List<Option> allOptions) {
+        JPanel panel = new JPanel(new MigLayout("fill, insets 0", "[grow][]", "[grow][]"));
+        panel.add(new JScrollPane(list), "grow, push");
+        JButton addButton = new JButton("Add");
+        JButton removeButton = new JButton("Remove");
+        addButton.addActionListener(e -> {
+            List<Option> available = new ArrayList<Option>();
+            Set<String> selected = new HashSet<String>();
+            for (int i = 0; i < model.size(); i++) {
+                selected.add(model.get(i).getId());
+            }
+            for (Option option : allOptions) {
+                if (!selected.contains(option.getId())) {
+                    available.add(option);
+                }
+            }
+            if (!available.isEmpty()) {
+                Option option = (Option) JOptionPane.showInputDialog(this, "Select an item to add:", "Add", JOptionPane.PLAIN_MESSAGE, null,
+                        available.toArray(), available.get(0));
+                if (option != null) {
+                    model.addElement(option);
+                }
+            }
+        });
+        removeButton.addActionListener(e -> {
+            for (Option option : list.getSelectedValuesList()) {
+                model.removeElement(option);
+            }
+        });
+        JPanel controls = new JPanel(new MigLayout("insets 0, wrap"));
+        controls.add(addButton, "w 80!");
+        controls.add(removeButton, "w 80!");
+        panel.add(controls, "top");
+        return panel;
+    }
+
+    private boolean channelHasTag(Channel channel, String tagId) {
+        return sourceTagIds.contains(tagId);
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public String getChannelName() {
+        return nameField.getText().trim();
+    }
+
+    public boolean isIncludePruneSettings() {
+        return pruneCheckBox.isSelected();
+    }
+
+    public boolean isIncludeCodeTemplateLibraries() {
+        return codeTemplateCheckBox.isSelected();
+    }
+
+    public boolean isIncludeResources() {
+        return resourcesCheckBox.isSelected();
+    }
+
+    public String getGroupId() {
+        GroupOption group = (GroupOption) groupComboBox.getSelectedItem();
+        return group == null ? ChannelGroup.DEFAULT_ID : group.getId();
+    }
+
+    public Set<String> getTagIds() {
+        return getIds(tagModel);
+    }
+
+    public Set<String> getDependencyIds() {
+        return getIds(dependencyModel);
+    }
+
+    private Set<String> getIds(DefaultListModel<Option> model) {
+        Set<String> ids = new HashSet<String>();
+        for (int i = 0; i < model.size(); i++) {
+            ids.add(model.get(i).getId());
+        }
+        return ids;
+    }
+
+    public static class GroupOption {
+        private final String id;
+        private final String name;
+
+        public GroupOption(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/client/src/main/java/com/mirth/connect/client/ui/ChannelPanel.java
+++ b/client/src/main/java/com/mirth/connect/client/ui/ChannelPanel.java
@@ -105,6 +105,8 @@ import com.mirth.connect.client.ui.components.tag.TagFilterCompletion;
 import com.mirth.connect.client.ui.tag.SettingsPanelTags;
 import com.mirth.connect.client.ui.util.DisplayUtil;
 import com.mirth.connect.donkey.model.channel.DebugOptions;
+import com.mirth.connect.donkey.model.channel.DestinationConnectorPropertiesInterface;
+import com.mirth.connect.donkey.model.channel.SourceConnectorPropertiesInterface;
 import com.mirth.connect.donkey.util.DonkeyElement;
 import com.mirth.connect.donkey.util.DonkeyElement.DonkeyElementException;
 import com.mirth.connect.model.Channel;
@@ -115,6 +117,7 @@ import com.mirth.connect.model.ChannelMetadata;
 import com.mirth.connect.model.ChannelStatus;
 import com.mirth.connect.model.ChannelSummary;
 import com.mirth.connect.model.ChannelTag;
+import com.mirth.connect.model.Connector;
 import com.mirth.connect.model.DashboardStatus;
 import com.mirth.connect.model.InvalidChannel;
 import com.mirth.connect.model.codetemplates.CodeTemplate;
@@ -2261,46 +2264,148 @@ public class ChannelPanel extends AbstractFramePanel {
             return;
         }
 
+        Channel sourceChannel = channel;
+
+        List<ChannelCloneDialog.GroupOption> groups = new ArrayList<ChannelCloneDialog.GroupOption>();
+        String sourceGroupId = ChannelGroup.DEFAULT_ID;
+        for (ChannelGroupStatus groupStatus : groupStatuses.values()) {
+            ChannelGroup group = groupStatus.getGroup();
+            groups.add(new ChannelCloneDialog.GroupOption(group.getId(), group.getName()));
+            for (ChannelStatus status : groupStatus.getChannelStatuses()) {
+                if (sourceChannel.getId().equals(status.getChannel().getId())) {
+                    sourceGroupId = group.getId();
+                }
+            }
+        }
+
+        String cloneId;
         try {
-            channel = (Channel) SerializationUtils.clone(channel);
+            cloneId = parent.mirthClient.getGuid();
+        } catch (ClientException e) {
+            parent.alertThrowable(parent, e);
+            return;
+        }
+
+        boolean hasCodeTemplateLibraries = false;
+        for (CodeTemplateLibrary library : parent.codeTemplatePanel.getCachedCodeTemplateLibraries().values()) {
+            if (library.getEnabledChannelIds().contains(sourceChannel.getId()) || (library.isIncludeNewChannels() && !library.getDisabledChannelIds().contains(sourceChannel.getId()))) {
+                hasCodeTemplateLibraries = true;
+                break;
+            }
+        }
+
+        boolean hasResources = channelHasResources(channel);
+        final String reservedCloneId = cloneId;
+        ChannelCloneDialog dialog = new ChannelCloneDialog(parent, sourceChannel, getCachedChannelTags(), getCachedChannelDependencies(), groups, sourceGroupId,
+                hasCodeTemplateLibraries, hasResources, name -> parent.checkChannelName(name, reservedCloneId));
+        if (!dialog.isConfirmed()) {
+            return;
+        }
+
+        try {
+            channel = (Channel) SerializationUtils.clone(sourceChannel);
         } catch (SerializationException e) {
             parent.alertThrowable(parent, e);
             return;
         }
 
-        // Before overwriting the ID, get all associated tags 
-        List<ChannelTag> channelTags = new ArrayList<ChannelTag>();
+        channel.setRevision(0);
+        channel.setId(reservedCloneId);
+
+        channel.setName(dialog.getChannelName());
+
+        if (!dialog.isIncludePruneSettings()) {
+            channel.getExportData().getMetadata().setPruningSettings(null);
+        }
+
+        updateCodeTemplateLibrariesForClone(sourceChannel.getId(), channel.getId(), dialog.isIncludeCodeTemplateLibraries());
+        if (!dialog.isIncludeCodeTemplateLibraries()) {
+            channel.getExportData().clearCodeTemplateLibraries();
+        }
+
+        if (!dialog.isIncludeResources()) {
+            clearChannelResources(channel);
+        }
+
+        List<ChannelTag> selectedTags = new ArrayList<ChannelTag>();
         for (ChannelTag tag : getCachedChannelTags()) {
-            if (tag.getChannelIds().contains(channel.getId())) {
-                channelTags.add(tag);
+            if (dialog.getTagIds().contains(tag.getId())) {
+                selectedTags.add(tag);
             }
         }
+        updateChannelTags(selectedTags, channel.getId());
+        channel.getExportData().setChannelTags(new ArrayList<ChannelTag>(selectedTags));
 
-        try {
-            channel.setRevision(0);
-            channel.setId(parent.mirthClient.getGuid());
-        } catch (ClientException e) {
-            parent.alertThrowable(parent, e);
-        }
-
-        String channelName = channel.getName();
-        do {
-            channelName = DisplayUtil.showInputDialog(this, "Please enter a new name for the channel.", channelName);
-            if (channelName == null) {
-                return;
-            }
-        } while (!parent.checkChannelName(channelName, channel.getId()));
-
-        channel.setName(channelName);
+        channel.getExportData().clearDependencies();
+        channel.getExportData().setDependencyIds(dialog.getDependencyIds());
         channelStatuses.put(channel.getId(), new ChannelStatus(channel));
 
-        // Add the cloned channel's ID to any tags
-        for (ChannelTag tag : channelTags) {
-            tag.getChannelIds().add(channel.getId());
+        Set<ChannelDependency> channelDependencies = new HashSet<ChannelDependency>(getCachedChannelDependencies());
+        for (String dependencyId : dialog.getDependencyIds()) {
+            channelDependencies.add(new ChannelDependency(channel.getId(), dependencyId));
+        }
+        try {
+            parent.mirthClient.setChannelDependencies(channelDependencies);
+        } catch (ClientException e) {
+            parent.alertThrowable(parent, e, "Unable to copy channel dependencies.");
         }
 
-        parent.editChannel(channel);
+        parent.editChannel(channel, dialog.getGroupId());
         parent.setSaveEnabled(true);
+    }
+
+    private void updateCodeTemplateLibrariesForClone(String sourceId, String cloneId, boolean include) {
+        Map<String, CodeTemplateLibrary> libraries = new HashMap<String, CodeTemplateLibrary>();
+        for (CodeTemplateLibrary library : parent.codeTemplatePanel.getCachedCodeTemplateLibraries().values()) {
+            boolean linked = library.getEnabledChannelIds().contains(sourceId) || (library.isIncludeNewChannels() && !library.getDisabledChannelIds().contains(sourceId));
+            if (linked) {
+                CodeTemplateLibrary updated = new CodeTemplateLibrary(library);
+                updated.getEnabledChannelIds().remove(cloneId);
+                updated.getDisabledChannelIds().remove(cloneId);
+                if (include) {
+                    updated.getEnabledChannelIds().add(cloneId);
+                } else {
+                    updated.getDisabledChannelIds().add(cloneId);
+                }
+                libraries.put(updated.getId(), updated);
+            }
+        }
+
+        if (!libraries.isEmpty()) {
+            CodeTemplateLibrarySaveResult result = parent.codeTemplatePanel.attemptUpdate(libraries, new HashMap<String, CodeTemplateLibrary>(), new HashMap<String, CodeTemplate>(), new HashMap<String, CodeTemplate>(), true, null, null);
+            if (result == null || !result.isLibrariesSuccess()) {
+                parent.alertWarning(parent, "Unable to copy code template library assignments.");
+            }
+        }
+    }
+
+    private void clearChannelResources(Channel channel) {
+        channel.getProperties().getResourceIds().clear();
+        if (channel.getSourceConnector() != null && channel.getSourceConnector().getProperties() instanceof SourceConnectorPropertiesInterface) {
+            ((SourceConnectorPropertiesInterface) channel.getSourceConnector().getProperties()).getSourceConnectorProperties().getResourceIds().clear();
+        }
+        for (Connector connector : channel.getDestinationConnectors()) {
+            if (connector.getProperties() instanceof DestinationConnectorPropertiesInterface) {
+                ((DestinationConnectorPropertiesInterface) connector.getProperties()).getDestinationConnectorProperties().getResourceIds().clear();
+            }
+        }
+    }
+
+    private boolean channelHasResources(Channel channel) {
+        if (!channel.getProperties().getResourceIds().isEmpty()) {
+            return true;
+        }
+        if (channel.getSourceConnector() != null && channel.getSourceConnector().getProperties() instanceof SourceConnectorPropertiesInterface
+                && !((SourceConnectorPropertiesInterface) channel.getSourceConnector().getProperties()).getSourceConnectorProperties().getResourceIds().isEmpty()) {
+            return true;
+        }
+        for (Connector connector : channel.getDestinationConnectors()) {
+            if (connector.getProperties() instanceof DestinationConnectorPropertiesInterface
+                    && !((DestinationConnectorPropertiesInterface) connector.getProperties()).getDestinationConnectorProperties().getResourceIds().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void doEditChannel() {

--- a/client/src/main/java/com/mirth/connect/client/ui/ChannelSetup.java
+++ b/client/src/main/java/com/mirth/connect/client/ui/ChannelSetup.java
@@ -511,6 +511,10 @@ public class ChannelSetup extends JPanel {
 
     /** Sets the overall panel to edit the channel with the given channel index. */
     public void editChannel(Channel channel) {
+        editChannel(channel, null);
+    }
+
+    public void editChannel(Channel channel, String groupId) {
         loadingChannel = true;
         dateStartEdit = Calendar.getInstance();
 
@@ -524,7 +528,7 @@ public class ChannelSetup extends JPanel {
         channelValidationFailed = false;
         lastModelIndex = -1;
         currentChannel = channel;
-        saveGroupId = null;
+        saveGroupId = groupId;
         setResourceIds();
         setChannelTags();
 

--- a/client/src/main/java/com/mirth/connect/client/ui/Frame.java
+++ b/client/src/main/java/com/mirth/connect/client/ui/Frame.java
@@ -858,6 +858,10 @@ public class Frame extends JXFrame {
      * editor.
      */
     public void editChannel(Channel channel) {
+        editChannel(channel, null);
+    }
+
+    public void editChannel(Channel channel, String groupId) {
         String alertMessage = channelEditPanel.checkInvalidPluginProperties(channel);
         if (StringUtils.isNotBlank(alertMessage)) {
             if (!alertOption(this, alertMessage + "\nWhen this channel is saved, those properties will be lost. You can choose to import/edit\nthis channel at a later time after verifying that all necessary extensions are properly loaded.\nAre you sure you wish to continue?")) {
@@ -870,7 +874,7 @@ public class Frame extends JXFrame {
         setCurrentContentPage(channelEditPanel);
         setFocus(channelEditTasks);
         setVisibleTasks(channelEditTasks, channelEditPopupMenu, 0, 4, false);
-        channelEditPanel.editChannel(channel);
+        channelEditPanel.editChannel(channel, groupId);
     }
 
     /**


### PR DESCRIPTION
## Summary

Implements Issue #153 by adding a configurable channel clone dialog.
<img width="635" height="529" alt="image" src="https://github.com/user-attachments/assets/a9abd6b6-9ddf-42d9-af20-ca862c1e7055" />

https://github.com/OpenIntegrationEngine/engine/issues/153

Users can now choose what to copy when cloning a channel, including:

- Channel name, with validation
- Prune settings
- Group membership
- Tags
- Outbound channel dependencies
- Code Template Library assignments
- Shared resource assignments

The clone receives a new GUID and revision zero, preserves the source channel, and opens in the normal channel editor for review before saving.

## Additional fixes

- Default clone name is `<source name>1`.
- Tags use the shared channel-tag association path so they persist correctly and appear in Settings → Tags.
- Inbound dependencies are not copied or modified.
- Existing clone behavior remains available through the new dialog.

## Testing

- Client compilation passes with:

```powershell
.\gradlew.bat :client:compileJava --no-daemon
```

Compiled and tested in the Client/Server on Windows10:
- Dependencies are carried over and can be toggled.
- Prune Settings are carried over and can be toggled.
- Tags are carried over and can be toggled.
- Group Membership are carried over and can be toggled.
- Code Templates are carried over and can be toggled.
- Resources are carried over and can be toggled.

Hard to capture in pictures, but proof that I went in and tested the endpoints at least.
<img width="722" height="822" alt="image" src="https://github.com/user-attachments/assets/349ff127-50d0-4b4a-802c-fe40dfaa70f8" />

