### PR TITLE
Fix #120: start and stop each server plugin only once

### DIFF
--- a/server/src/main/java/com/mirth/connect/server/controllers/DefaultExtensionController.java
+++ b/server/src/main/java/com/mirth/connect/server/controllers/DefaultExtensionController.java
@@ -84,7 +84,14 @@ public class DefaultExtensionController extends ExtensionController {
 
     // these are plugins for specific extension points, keyed by plugin name
     // (not path)
-    private List<ServerPlugin> serverPlugins = new ArrayList<ServerPlugin>();
+    /*
+     * A plugin class may implement several of the plugin type interfaces, in which case it is
+     * registered once for each interface it implements. A Set holds a single entry per plugin,
+     * so start() and stop() are invoked once per plugin rather than once per interface.
+     * LinkedHashSet because initPlugins loads plugins in a deliberate order (by plugin weight)
+     * and that order is preserved when they are started and stopped.
+     */
+    private Set<ServerPlugin> serverPlugins = new LinkedHashSet<ServerPlugin>();
     private Map<String, ServicePlugin> servicePlugins = new LinkedHashMap<String, ServicePlugin>();
     private Map<String, ChannelPlugin> channelPlugins = new LinkedHashMap<String, ChannelPlugin>();
     private Map<String, CodeTemplateServerPlugin> codeTemplateServerPlugins = new LinkedHashMap<String, CodeTemplateServerPlugin>();
@@ -240,42 +247,42 @@ public class DefaultExtensionController extends ExtensionController {
                          */
                         servicePlugin.init(currentProperties);
                         servicePlugins.put(servicePlugin.getPluginPointName(), servicePlugin);
-                        addServerPlugin(servicePlugin);
+                        serverPlugins.add(servicePlugin);
                         logger.debug("sucessfully loaded server plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof ChannelPlugin) {
                         ChannelPlugin channelPlugin = (ChannelPlugin) serverPlugin;
                         channelPlugins.put(channelPlugin.getPluginPointName(), channelPlugin);
-                        addServerPlugin(channelPlugin);
+                        serverPlugins.add(channelPlugin);
                         logger.debug("sucessfully loaded server channel plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof CodeTemplateServerPlugin) {
                         CodeTemplateServerPlugin codeTemplateServerPlugin = (CodeTemplateServerPlugin) serverPlugin;
                         codeTemplateServerPlugins.put(codeTemplateServerPlugin.getPluginPointName(), codeTemplateServerPlugin);
-                        addServerPlugin(codeTemplateServerPlugin);
+                        serverPlugins.add(codeTemplateServerPlugin);
                         logger.debug("sucessfully loaded server code template plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof DataTypeServerPlugin) {
                         DataTypeServerPlugin dataTypePlugin = (DataTypeServerPlugin) serverPlugin;
                         dataTypePlugins.put(dataTypePlugin.getPluginPointName(), dataTypePlugin);
-                        addServerPlugin(dataTypePlugin);
+                        serverPlugins.add(dataTypePlugin);
                         logger.debug("sucessfully loaded server data type plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof ResourcePlugin) {
                         ResourcePlugin resourcePlugin = (ResourcePlugin) serverPlugin;
                         resourcePlugins.put(resourcePlugin.getPluginPointName(), resourcePlugin);
-                        addServerPlugin(resourcePlugin);
+                        serverPlugins.add(resourcePlugin);
                         logger.debug("Successfully loaded resource plugin: " + resourcePlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof TransmissionModeProvider) {
                         TransmissionModeProvider transmissionModeProvider = (TransmissionModeProvider) serverPlugin;
                         transmissionModeProviders.put(transmissionModeProvider.getPluginPointName(), transmissionModeProvider);
-                        addServerPlugin(transmissionModeProvider);
+                        serverPlugins.add(transmissionModeProvider);
                         logger.debug("Successfully loaded transmission mode provider plugin: " + transmissionModeProvider.getPluginPointName());
                     }
 
@@ -287,7 +294,7 @@ public class DefaultExtensionController extends ExtensionController {
                         }
 
                         this.authorizationPlugin = authorizationPlugin;
-                        addServerPlugin(authorizationPlugin);
+                        serverPlugins.add(authorizationPlugin);
                         logger.debug("sucessfully loaded server authorization plugin: " + serverPlugin.getPluginPointName());
                     }
 
@@ -299,7 +306,7 @@ public class DefaultExtensionController extends ExtensionController {
                         }
 
                         this.multiFactorAuthenticationPlugin = multiFactorAuthenticationPlugin;
-                        addServerPlugin(multiFactorAuthenticationPlugin);
+                        serverPlugins.add(multiFactorAuthenticationPlugin);
                         logger.debug("sucessfully loaded server multi-factor authentication plugin: " + serverPlugin.getPluginPointName());
                     }
                 } catch (Exception e) {
@@ -307,32 +314,6 @@ public class DefaultExtensionController extends ExtensionController {
                 }
             }
         }
-    }
-
-    /**
-     * Registers a plugin in the list used to start and stop all server plugins.
-     * <p>
-     * A single plugin class may implement more than one of the plugin type interfaces (for example
-     * both {@link ServicePlugin} and {@link ChannelPlugin}). Such a plugin is registered against
-     * each type it implements, so this method guards against adding the same instance more than
-     * once. Without the guard, {@link #startPlugins()} and {@link #stopPlugins()} would invoke
-     * {@link ServerPlugin#start()} and {@link ServerPlugin#stop()} once per implemented interface
-     * rather than once per plugin.
-     * <p>
-     * Instances are compared by identity on purpose. Two distinct plugin instances must both be
-     * registered even if the plugin class considers them equal.
-     * <p>
-     * Package private so it can be exercised directly by unit tests without going through the full
-     * extension loading process.
-     */
-    void addServerPlugin(ServerPlugin serverPlugin) {
-        for (ServerPlugin registeredPlugin : serverPlugins) {
-            if (registeredPlugin == serverPlugin) {
-                return;
-            }
-        }
-
-        serverPlugins.add(serverPlugin);
     }
 
     /* These are the maps for the different types of plugins */
@@ -742,7 +723,8 @@ public class DefaultExtensionController extends ExtensionController {
     }
 
     public List<ServerPlugin> getServerPlugins() {
-        return serverPlugins;
+        // Copied into a List so the ExtensionController signature stays unchanged for extensions.
+        return new ArrayList<ServerPlugin>(serverPlugins);
     }
 
     void extractZipEntry(ZipEntry entry, File installTempDir, ZipFile zipFile) throws IOException {

--- a/server/src/main/java/com/mirth/connect/server/controllers/DefaultExtensionController.java
+++ b/server/src/main/java/com/mirth/connect/server/controllers/DefaultExtensionController.java
@@ -240,42 +240,42 @@ public class DefaultExtensionController extends ExtensionController {
                          */
                         servicePlugin.init(currentProperties);
                         servicePlugins.put(servicePlugin.getPluginPointName(), servicePlugin);
-                        serverPlugins.add(servicePlugin);
+                        addServerPlugin(servicePlugin);
                         logger.debug("sucessfully loaded server plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof ChannelPlugin) {
                         ChannelPlugin channelPlugin = (ChannelPlugin) serverPlugin;
                         channelPlugins.put(channelPlugin.getPluginPointName(), channelPlugin);
-                        serverPlugins.add(channelPlugin);
+                        addServerPlugin(channelPlugin);
                         logger.debug("sucessfully loaded server channel plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof CodeTemplateServerPlugin) {
                         CodeTemplateServerPlugin codeTemplateServerPlugin = (CodeTemplateServerPlugin) serverPlugin;
                         codeTemplateServerPlugins.put(codeTemplateServerPlugin.getPluginPointName(), codeTemplateServerPlugin);
-                        serverPlugins.add(codeTemplateServerPlugin);
+                        addServerPlugin(codeTemplateServerPlugin);
                         logger.debug("sucessfully loaded server code template plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof DataTypeServerPlugin) {
                         DataTypeServerPlugin dataTypePlugin = (DataTypeServerPlugin) serverPlugin;
                         dataTypePlugins.put(dataTypePlugin.getPluginPointName(), dataTypePlugin);
-                        serverPlugins.add(dataTypePlugin);
+                        addServerPlugin(dataTypePlugin);
                         logger.debug("sucessfully loaded server data type plugin: " + serverPlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof ResourcePlugin) {
                         ResourcePlugin resourcePlugin = (ResourcePlugin) serverPlugin;
                         resourcePlugins.put(resourcePlugin.getPluginPointName(), resourcePlugin);
-                        serverPlugins.add(resourcePlugin);
+                        addServerPlugin(resourcePlugin);
                         logger.debug("Successfully loaded resource plugin: " + resourcePlugin.getPluginPointName());
                     }
 
                     if (serverPlugin instanceof TransmissionModeProvider) {
                         TransmissionModeProvider transmissionModeProvider = (TransmissionModeProvider) serverPlugin;
                         transmissionModeProviders.put(transmissionModeProvider.getPluginPointName(), transmissionModeProvider);
-                        serverPlugins.add(transmissionModeProvider);
+                        addServerPlugin(transmissionModeProvider);
                         logger.debug("Successfully loaded transmission mode provider plugin: " + transmissionModeProvider.getPluginPointName());
                     }
 
@@ -287,7 +287,7 @@ public class DefaultExtensionController extends ExtensionController {
                         }
 
                         this.authorizationPlugin = authorizationPlugin;
-                        serverPlugins.add(authorizationPlugin);
+                        addServerPlugin(authorizationPlugin);
                         logger.debug("sucessfully loaded server authorization plugin: " + serverPlugin.getPluginPointName());
                     }
 
@@ -299,7 +299,7 @@ public class DefaultExtensionController extends ExtensionController {
                         }
 
                         this.multiFactorAuthenticationPlugin = multiFactorAuthenticationPlugin;
-                        serverPlugins.add(multiFactorAuthenticationPlugin);
+                        addServerPlugin(multiFactorAuthenticationPlugin);
                         logger.debug("sucessfully loaded server multi-factor authentication plugin: " + serverPlugin.getPluginPointName());
                     }
                 } catch (Exception e) {
@@ -307,6 +307,32 @@ public class DefaultExtensionController extends ExtensionController {
                 }
             }
         }
+    }
+
+    /**
+     * Registers a plugin in the list used to start and stop all server plugins.
+     * <p>
+     * A single plugin class may implement more than one of the plugin type interfaces (for example
+     * both {@link ServicePlugin} and {@link ChannelPlugin}). Such a plugin is registered against
+     * each type it implements, so this method guards against adding the same instance more than
+     * once. Without the guard, {@link #startPlugins()} and {@link #stopPlugins()} would invoke
+     * {@link ServerPlugin#start()} and {@link ServerPlugin#stop()} once per implemented interface
+     * rather than once per plugin.
+     * <p>
+     * Instances are compared by identity on purpose. Two distinct plugin instances must both be
+     * registered even if the plugin class considers them equal.
+     * <p>
+     * Package private so it can be exercised directly by unit tests without going through the full
+     * extension loading process.
+     */
+    void addServerPlugin(ServerPlugin serverPlugin) {
+        for (ServerPlugin registeredPlugin : serverPlugins) {
+            if (registeredPlugin == serverPlugin) {
+                return;
+            }
+        }
+
+        serverPlugins.add(serverPlugin);
     }
 
     /* These are the maps for the different types of plugins */

--- a/server/src/test/java/com/mirth/connect/server/controllers/DefaultExtensionControllerTest.java
+++ b/server/src/test/java/com/mirth/connect/server/controllers/DefaultExtensionControllerTest.java
@@ -9,12 +9,9 @@
 
 package com.mirth.connect.server.controllers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -23,7 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.mirth.connect.plugins.ServerPlugin;
 import com.mirth.connect.util.ZipTestUtils;
 
 public class DefaultExtensionControllerTest {
@@ -75,99 +71,5 @@ public class DefaultExtensionControllerTest {
 
     private ZipFile createTempZipFile(String fileName) throws Exception {
         return new ZipFile(ZipTestUtils.createTempZipFile(fileName));
-    }
-
-    /*
-     * A plugin class may implement several of the plugin type interfaces (ServicePlugin,
-     * ChannelPlugin, and so on). initPlugins registers the instance once per interface it
-     * implements, so registration must ignore an instance that is already registered. Otherwise
-     * start() and stop() get invoked once per implemented interface instead of once per plugin.
-     */
-    @Test
-    public void testAddServerPluginIgnoresDuplicateRegistrationOfSameInstance() {
-        DefaultExtensionController extensionController = new DefaultExtensionController();
-        CountingServerPlugin plugin = new CountingServerPlugin("multi-type plugin");
-
-        extensionController.addServerPlugin(plugin);
-        extensionController.addServerPlugin(plugin);
-        extensionController.addServerPlugin(plugin);
-
-        List<ServerPlugin> registeredPlugins = extensionController.getServerPlugins();
-        assertEquals(1, registeredPlugins.size());
-        assertSame(plugin, registeredPlugins.get(0));
-    }
-
-    @Test
-    public void testStopPluginsStopsPluginRegisteredForMultipleTypesOnce() {
-        DefaultExtensionController extensionController = new DefaultExtensionController();
-        CountingServerPlugin plugin = new CountingServerPlugin("multi-type plugin");
-
-        extensionController.addServerPlugin(plugin);
-        extensionController.addServerPlugin(plugin);
-
-        extensionController.stopPlugins();
-
-        assertEquals(1, plugin.stopCount);
-    }
-
-    /*
-     * Registration deliberately compares instances by identity, so two separate plugin instances
-     * are both registered and both stopped even when the plugin class reports them as equal.
-     */
-    @Test
-    public void testAddServerPluginRegistersDistinctButEqualInstancesSeparately() {
-        DefaultExtensionController extensionController = new DefaultExtensionController();
-        AlwaysEqualServerPlugin firstPlugin = new AlwaysEqualServerPlugin();
-        AlwaysEqualServerPlugin secondPlugin = new AlwaysEqualServerPlugin();
-
-        extensionController.addServerPlugin(firstPlugin);
-        extensionController.addServerPlugin(secondPlugin);
-
-        assertEquals(2, extensionController.getServerPlugins().size());
-
-        extensionController.stopPlugins();
-
-        assertEquals(1, firstPlugin.stopCount);
-        assertEquals(1, secondPlugin.stopCount);
-    }
-
-    private static class CountingServerPlugin implements ServerPlugin {
-        private final String pluginPointName;
-        int stopCount;
-
-        private CountingServerPlugin(String pluginPointName) {
-            this.pluginPointName = pluginPointName;
-        }
-
-        @Override
-        public String getPluginPointName() {
-            return pluginPointName;
-        }
-
-        @Override
-        public void start() {
-            // Not exercised here: startPlugins() also reaches into ControllerFactory.
-        }
-
-        @Override
-        public void stop() {
-            stopCount++;
-        }
-    }
-
-    private static class AlwaysEqualServerPlugin extends CountingServerPlugin {
-        private AlwaysEqualServerPlugin() {
-            super("always equal plugin");
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            return other instanceof AlwaysEqualServerPlugin;
-        }
-
-        @Override
-        public int hashCode() {
-            return AlwaysEqualServerPlugin.class.hashCode();
-        }
     }
 }

--- a/server/src/test/java/com/mirth/connect/server/controllers/DefaultExtensionControllerTest.java
+++ b/server/src/test/java/com/mirth/connect/server/controllers/DefaultExtensionControllerTest.java
@@ -9,9 +9,12 @@
 
 package com.mirth.connect.server.controllers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -20,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.mirth.connect.plugins.ServerPlugin;
 import com.mirth.connect.util.ZipTestUtils;
 
 public class DefaultExtensionControllerTest {
@@ -71,5 +75,99 @@ public class DefaultExtensionControllerTest {
 
     private ZipFile createTempZipFile(String fileName) throws Exception {
         return new ZipFile(ZipTestUtils.createTempZipFile(fileName));
+    }
+
+    /*
+     * A plugin class may implement several of the plugin type interfaces (ServicePlugin,
+     * ChannelPlugin, and so on). initPlugins registers the instance once per interface it
+     * implements, so registration must ignore an instance that is already registered. Otherwise
+     * start() and stop() get invoked once per implemented interface instead of once per plugin.
+     */
+    @Test
+    public void testAddServerPluginIgnoresDuplicateRegistrationOfSameInstance() {
+        DefaultExtensionController extensionController = new DefaultExtensionController();
+        CountingServerPlugin plugin = new CountingServerPlugin("multi-type plugin");
+
+        extensionController.addServerPlugin(plugin);
+        extensionController.addServerPlugin(plugin);
+        extensionController.addServerPlugin(plugin);
+
+        List<ServerPlugin> registeredPlugins = extensionController.getServerPlugins();
+        assertEquals(1, registeredPlugins.size());
+        assertSame(plugin, registeredPlugins.get(0));
+    }
+
+    @Test
+    public void testStopPluginsStopsPluginRegisteredForMultipleTypesOnce() {
+        DefaultExtensionController extensionController = new DefaultExtensionController();
+        CountingServerPlugin plugin = new CountingServerPlugin("multi-type plugin");
+
+        extensionController.addServerPlugin(plugin);
+        extensionController.addServerPlugin(plugin);
+
+        extensionController.stopPlugins();
+
+        assertEquals(1, plugin.stopCount);
+    }
+
+    /*
+     * Registration deliberately compares instances by identity, so two separate plugin instances
+     * are both registered and both stopped even when the plugin class reports them as equal.
+     */
+    @Test
+    public void testAddServerPluginRegistersDistinctButEqualInstancesSeparately() {
+        DefaultExtensionController extensionController = new DefaultExtensionController();
+        AlwaysEqualServerPlugin firstPlugin = new AlwaysEqualServerPlugin();
+        AlwaysEqualServerPlugin secondPlugin = new AlwaysEqualServerPlugin();
+
+        extensionController.addServerPlugin(firstPlugin);
+        extensionController.addServerPlugin(secondPlugin);
+
+        assertEquals(2, extensionController.getServerPlugins().size());
+
+        extensionController.stopPlugins();
+
+        assertEquals(1, firstPlugin.stopCount);
+        assertEquals(1, secondPlugin.stopCount);
+    }
+
+    private static class CountingServerPlugin implements ServerPlugin {
+        private final String pluginPointName;
+        int stopCount;
+
+        private CountingServerPlugin(String pluginPointName) {
+            this.pluginPointName = pluginPointName;
+        }
+
+        @Override
+        public String getPluginPointName() {
+            return pluginPointName;
+        }
+
+        @Override
+        public void start() {
+            // Not exercised here: startPlugins() also reaches into ControllerFactory.
+        }
+
+        @Override
+        public void stop() {
+            stopCount++;
+        }
+    }
+
+    private static class AlwaysEqualServerPlugin extends CountingServerPlugin {
+        private AlwaysEqualServerPlugin() {
+            super("always equal plugin");
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof AlwaysEqualServerPlugin;
+        }
+
+        @Override
+        public int hashCode() {
+            return AlwaysEqualServerPlugin.class.hashCode();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #120. A plugin whose class implements several of the plugin type interfaces was registered once per interface, so it was started and stopped multiple times.

## Root cause

`DefaultExtensionController.initPlugins()` checks each loaded plugin against every plugin type in turn, and each of the eight branches adds the instance to the same `serverPlugins` collection:

```java
if (serverPlugin instanceof ServicePlugin) { ... serverPlugins.add(servicePlugin); }
if (serverPlugin instanceof ChannelPlugin) { ... serverPlugins.add(channelPlugin); }
// ...six more
```

Because that collection was an `ArrayList`, a class implementing both `ServicePlugin` and `ChannelPlugin` ends up in it twice.

Note the issue title mentions `close()`; the methods actually affected are `start()` and `stop()` on `ServerPlugin`.

## Impact beyond start/stop

The duplicate entries affect every consumer of that collection, not just shutdown:

- `startPlugins()` / `stopPlugins()` invoke `start()` and `stop()` once per implemented interface instead of once per plugin. This is the shutdown noise reported in the issue.
- `AlertWorker` builds its `alertActionAcceptors` list by iterating `getServerPlugins()` and filtering on `instanceof AlertActionAcceptor`, so a duplicated plugin is added repeatedly and its alert actions run once per implemented interface.
- `DefaultUsageController` reports plugin usage from the same collection, so counts are inflated for multi-interface plugins.

## Fix

`serverPlugins` is now a `Set`, so a plugin registered for several interfaces is held once and the de-duplication is the natural behaviour of the collection. The eight registration calls are unchanged.

`LinkedHashSet` rather than `HashSet`: `initPlugins()` deliberately loads plugins in descending plugin weight order, and preserving that order means they are started and stopped in the intended sequence.

`getServerPlugins()` still returns `List<ServerPlugin>`, so the `ExtensionController` signature is unchanged for extensions. It now returns a copy rather than the live internal collection.

Net change is 10 insertions and 2 deletions in one file.

## On testing

The earlier revision of this PR routed the registrations through a de-duplicating helper and unit tested it. Following review that has been dropped in favour of the `Set`, and the tests went with it: they exercised the helper directly, and the invariant is now enforced by the collection type rather than by logic of our own.

Testing this through `initPlugins()` instead is not really reachable from a unit test, since it requires plugin metadata loading plus database access via `setPluginProperties`. If you would like coverage here, I am happy to look at an integration-level test.

Verified with `./gradlew :server:test` (613 tests, 0 failures) and `./gradlew :donkey:test`.

## Note on the failing check

The `FileReceiverTest > testPoll1` failure on the previous commit is unrelated to this change, which touches only plugin registration. The assertion at `FileReceiverTest.java:133` counts files picked up by a poll, and it passes locally both in the full suite and across three consecutive isolated runs. Given the recent "Allow parallel tests" change, this looks like a timing-sensitive flake rather than a real regression.

## How to verify

Build a plugin whose class implements two `ServerPlugin` sub-interfaces, for example `ServicePlugin` and `ChannelPlugin`, and log a line in `stop()`. Before this change the line appears twice on server shutdown; after it, once.
