### PR TITLE
Run the Gradle build as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,20 +16,31 @@ SHELL ["/bin/bash", "-c"]
 ARG GRADLE_BUILD_ARGS="-PdisableSigning=true"
 
 # Stage 1a: Install dependencies
-# Install necessary tools
-COPY .sdkmanrc .
+# Install necessary tools, then drop root. The base image ships a
+# pre-created "ubuntu" user (uid 1000, the same one the runner stage
+# below renames to "engine") — reuse it so Gradle doesn't run as root,
+# which ignores POSIX permission bits and breaks tests that depend on
+# them (e.g. Log4jMigrationsTest's read-only-file assertion).
 RUN apt-get update\
     && apt-get install -y zip curl\
-    && curl -s "https://get.sdkman.io?ci=true" | bash \
-    && source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env install \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && chown ubuntu:ubuntu /app
+USER ubuntu
+
+COPY --chown=ubuntu:ubuntu .sdkmanrc .
+RUN curl -s "https://get.sdkman.io?ci=true" | bash \
+    && source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk env install
 
 # Stage 1b: Build the application
 # Copy the entire source tree (excluding .dockerignore files), and build
 # (file encoding is pinned to UTF-8 in gradle.properties)
-COPY . .
-RUN --mount=type=cache,target=/root/.gradle/caches,sharing=locked \
-    --mount=type=cache,target=/root/.gradle/wrapper,sharing=locked \
+COPY --chown=ubuntu:ubuntu . .
+# The cache mounts below own their own target dirs (uid/gid), but not the
+# ~/.gradle parent itself — Gradle also writes ~/.gradle/native (extracted
+# native-platform lib) outside either mount, so create the parent up front.
+RUN mkdir -p /home/ubuntu/.gradle
+RUN --mount=type=cache,target=/home/ubuntu/.gradle/caches,sharing=locked,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/ubuntu/.gradle/wrapper,sharing=locked,uid=1000,gid=1000 \
     source "$HOME/.sdkman/bin/sdkman-init.sh" \
     && ./gradlew --no-daemon build ${GRADLE_BUILD_ARGS}
 


### PR DESCRIPTION
The `builder` stage in the root `Dockerfile` has no `USER` directive, so Gradle runs as root. Root ignores POSIX permission bits, which breaks `Log4jMigrationsTest.testMigrateLog4jFailsGracefullyWithReadOnlyFile` — that test chmods a file read-only and asserts a write fails, but as root the write succeeds.

The practical effect is that a from-scratch `docker build` of the published Dockerfile either fails on that test, or has to be run with tests skipped — so the image build loses its test signal.

This drops to the `ubuntu` user (uid 1000) that `ubuntu:noble` already ships, rather than creating a new one — it's the same account the runner stages already rename to `engine`.

Notes on the details:

- `chown ubuntu:ubuntu /app` happens after `apt-get`, which still needs root.
- sdkman installs into `$HOME/.sdkman`; Docker sets `HOME=/home/ubuntu` once `USER ubuntu` is active, so no sdkman path changes were needed.
- The Gradle cache mounts move from `/root/.gradle/...` to `/home/ubuntu/.gradle/...` with `uid=1000,gid=1000`.
- One subtlety worth flagging for reviewers: the cache mounts own only the mounted subdirectories, not their parent, and Gradle extracts `libnative-platform.so` into `~/.gradle/native`, outside both mounts. A plain `mkdir -p /home/ubuntu/.gradle` layer before the build covers that. Without it the build fails with `Could not initialize native services > Failed to load native library 'libnative-platform.so' for Linux aarch64`.

Verified on `linux/arm64` with tests enabled (no skip flags): 636 tests, 0 failures, 0 errors, including all four `Log4jMigrationsTest` cases. The runner stage is untouched and the final image size is unchanged.