### PR TITLE
Allow == and != against empty string

### DIFF
--- a/client/src/main/java/com/mirth/connect/client/ui/browsers/message/MessageBrowserAdvancedFilter.java
+++ b/client/src/main/java/com/mirth/connect/client/ui/browsers/message/MessageBrowserAdvancedFilter.java
@@ -383,18 +383,22 @@ public class MessageBrowserAdvancedFilter extends MirthDialog {
         } else {
             for (int i = 0; i < rowCount; i++) {
                 String metaDataName = (String) model.getValueAt(i, 0);
-                String operator = ((MetaDataSearchOperator) model.getValueAt(i, 1)).toFullString();
+                MetaDataSearchOperator operator = (MetaDataSearchOperator) model.getValueAt(i, 1);
                 String searchText = (String) model.getValueAt(i, 2);
                 Boolean ignoreCase = (Boolean) model.getValueAt(i, 3);
+                MetaDataColumn column = cachedMetaDataColumns.get(metaDataName);
 
-                if (StringUtils.isNotEmpty(searchText)) {
-                    MetaDataColumn column = cachedMetaDataColumns.get(metaDataName);
-                    metaDataSearch.add(new MetaDataSearchElement(metaDataName, operator, column.getType().castValue(searchText), ignoreCase));
+                if (shouldIncludeMetaDataSearch(column.getType(), operator, searchText)) {
+                    metaDataSearch.add(new MetaDataSearchElement(metaDataName, operator.toFullString(), column.getType().castValue(searchText), ignoreCase));
                 }
             }
 
             return metaDataSearch;
         }
+    }
+
+    static boolean shouldIncludeMetaDataSearch(MetaDataColumnType columnType, MetaDataSearchOperator operator, String searchText) {
+        return StringUtils.isNotEmpty(searchText) || (columnType == MetaDataColumnType.STRING && (operator == MetaDataSearchOperator.EQUAL || operator == MetaDataSearchOperator.NOT_EQUAL));
     }
 
     @Override

--- a/client/src/test/java/com/mirth/connect/client/ui/browsers/message/MessageBrowserAdvancedFilterTest.java
+++ b/client/src/test/java/com/mirth/connect/client/ui/browsers/message/MessageBrowserAdvancedFilterTest.java
@@ -1,0 +1,30 @@
+package com.mirth.connect.client.ui.browsers.message;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.mirth.connect.donkey.model.channel.MetaDataColumnType;
+import com.mirth.connect.model.filters.elements.MetaDataSearchOperator;
+
+public class MessageBrowserAdvancedFilterTest {
+
+    @Test
+    public void shouldIncludeBlankStringEqualitySearches() {
+        assertTrue(MessageBrowserAdvancedFilter.shouldIncludeMetaDataSearch(MetaDataColumnType.STRING, MetaDataSearchOperator.EQUAL, ""));
+        assertTrue(MessageBrowserAdvancedFilter.shouldIncludeMetaDataSearch(MetaDataColumnType.STRING, MetaDataSearchOperator.NOT_EQUAL, ""));
+    }
+
+    @Test
+    public void shouldIgnoreBlankNonEqualitySearches() {
+        assertFalse(MessageBrowserAdvancedFilter.shouldIncludeMetaDataSearch(MetaDataColumnType.STRING, MetaDataSearchOperator.CONTAINS, ""));
+        assertFalse(MessageBrowserAdvancedFilter.shouldIncludeMetaDataSearch(MetaDataColumnType.NUMBER, MetaDataSearchOperator.EQUAL, ""));
+    }
+
+    @Test
+    public void shouldIncludeNonBlankSearches() {
+        assertTrue(MessageBrowserAdvancedFilter.shouldIncludeMetaDataSearch(MetaDataColumnType.STRING, MetaDataSearchOperator.CONTAINS, "value"));
+        assertTrue(MessageBrowserAdvancedFilter.shouldIncludeMetaDataSearch(MetaDataColumnType.NUMBER, MetaDataSearchOperator.EQUAL, "1"));
+    }
+}


### PR DESCRIPTION
Closes #300 

Example channel for testing
[search for empty string.xml](https://github.com/user-attachments/files/30762212/search.for.empty.string.xml)

Test matrix:
1. Searching for `== ''` works on message with matching empty metadata
2. Searching for `!= ''` works on message with matching populated metadata
3. Searching for `== ''` does not match on message with populated metadata
4. Searching for `!= ''` does not match on message with empty metadata
5. Other filter operators continue being ignored if the value is `''`

Not supported on Oracle.