### PR TITLE
Add support for CC and BCC to SmtpSender

### DIFF
--- a/client/src/main/java/com/mirth/connect/connectors/smtp/SmtpSender.java
+++ b/client/src/main/java/com/mirth/connect/connectors/smtp/SmtpSender.java
@@ -112,6 +112,8 @@ public class SmtpSender extends ConnectorSettingsPanel {
         properties.setUsername(usernameField.getText());
         properties.setPassword(new String(passwordField.getPassword()));
         properties.setTo(toField.getText());
+        properties.setCc(ccField.getText());
+        properties.setBcc(bccField.getText());
         properties.setFrom(fromField.getText());
         properties.setSubject(subjectField.getText());
 
@@ -185,6 +187,8 @@ public class SmtpSender extends ConnectorSettingsPanel {
         usernameField.setText(props.getUsername());
         passwordField.setText(props.getPassword());
         toField.setText(props.getTo());
+        ccField.setText(props.getCc());
+        bccField.setText(props.getBcc());
         fromField.setText(props.getFrom());
         subjectField.setText(props.getSubject());
 
@@ -257,13 +261,13 @@ public class SmtpSender extends ConnectorSettingsPanel {
             errors.append("\"Send Timeout\" is required\n");
         }
 
-        if (props.getTo().length() == 0) {
+        if (StringUtils.isBlank(props.getTo()) && StringUtils.isBlank(props.getCc()) && StringUtils.isBlank(props.getBcc())) {
             valid = false;
             if (highlight) {
                 toField.setBackground(UIConstants.INVALID_COLOR);
             }
 
-            errors.append("\"To\" is required\n");
+            errors.append("At least one of \"To\", \"CC\", or \"BCC\" is required\n");
         }
 
         if (props.getFrom().length() == 0) {
@@ -695,6 +699,12 @@ public class SmtpSender extends ConnectorSettingsPanel {
         toLabel = new JLabel("To:");
         toField = new MirthTextField();
 
+        ccLabel = new JLabel("CC:");
+        ccField = new MirthTextField();
+
+        bccLabel = new JLabel("BCC:");
+        bccField = new MirthTextField();
+
         fromLabel = new JLabel("From:");
         fromField = new MirthTextField();
 
@@ -828,6 +838,8 @@ public class SmtpSender extends ConnectorSettingsPanel {
         usernameField.setToolTipText("If the SMTP server requires authentication to send a message, enter the username here.");
         passwordField.setToolTipText("If the SMTP server requires authentication to send a message, enter the password here.");
         toField.setToolTipText("The name of the mailbox (person, usually) to which the email should be sent.");
+        ccField.setToolTipText("Addresses to carbon copy the email to.");
+        bccField.setToolTipText("Addresses to blind carbon copy the email to.");
         fromField.setToolTipText("The name that should appear as the \"From address\" in the email.");
         subjectField.setToolTipText("The text that should appear as the subject of the email, as seen by the receiver's email client.");
         charsetEncodingComboBox.setToolTipText(String.format("<html>Select the character set encoding used by the sender of the message,<br> or Default to assume the default character set encoding for the JVM running %s.</html>", BrandingConstants.PRODUCT_NAME));
@@ -875,6 +887,10 @@ public class SmtpSender extends ConnectorSettingsPanel {
         add(passwordField, "w 125!, sx");
         add(toLabel, "newline, right");
         add(toField, "w 200!, sx");
+        add(ccLabel, "newline, right");
+        add(ccField, "w 200!, sx");
+        add(bccLabel, "newline, right");
+        add(bccField, "w 200!, sx");
         add(fromLabel, "newline, right");
         add(fromField, "w 200!, sx");
         add(subjectLabel, "newline, right");
@@ -1035,6 +1051,10 @@ public class SmtpSender extends ConnectorSettingsPanel {
     private MirthPasswordField passwordField;
     private JLabel toLabel;
     private MirthTextField toField;
+    private JLabel ccLabel;
+    private MirthTextField ccField;
+    private JLabel bccLabel;
+    private MirthTextField bccField;
     private JLabel fromLabel;
     private MirthTextField fromField;
     private JLabel subjectLabel;

--- a/server/src/main/java/com/mirth/connect/connectors/smtp/SmtpConnectorServlet.java
+++ b/server/src/main/java/com/mirth/connect/connectors/smtp/SmtpConnectorServlet.java
@@ -43,6 +43,8 @@ public class SmtpConnectorServlet extends MirthServlet implements SmtpConnectorS
             props.put("username", replacer.replaceValues(properties.getUsername(), channelId, channelName));
             props.put("password", replacer.replaceValues(properties.getPassword(), channelId, channelName));
             props.put("toAddress", replacer.replaceValues(properties.getTo(), channelId, channelName));
+            props.put("ccAddress", replacer.replaceValues(properties.getCc(), channelId, channelName));
+            props.put("bccAddress", replacer.replaceValues(properties.getBcc(), channelId, channelName));
             props.put("fromAddress", replacer.replaceValues(properties.getFrom(), channelId, channelName));
 
             return configurationController.sendTestEmail(props);

--- a/server/src/main/java/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/main/java/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -1636,6 +1636,8 @@ public class DefaultConfigurationController extends ConfigurationController {
         String username = properties.getProperty("username");
         String password = properties.getProperty("password");
         String to = properties.getProperty("toAddress");
+        String cc = properties.getProperty("ccAddress");
+        String bcc = properties.getProperty("bccAddress");
         String from = properties.getProperty("fromAddress");
 
         int port = -1;
@@ -1688,6 +1690,14 @@ public class DefaultConfigurationController extends ConfigurationController {
         try {
             for (String toAddress : StringUtils.split(to, ",")) {
                 email.addTo(toAddress);
+            }
+
+            for (String ccAddress : StringUtils.split(cc, ",")) {
+                email.addCc(ccAddress);
+            }
+
+            for (String bccAddress : StringUtils.split(bcc, ",")) {
+                email.addBcc(bccAddress);
             }
 
             email.setFrom(from);


### PR DESCRIPTION
Adds CC and BCC fields, updates validation logic to require only one of To/CC/BCC to be present.

https://discord.com/channels/943670759891554316/1535435394324111410

<img width="1923" height="1051" alt="image" src="https://github.com/user-attachments/assets/d3219556-2951-4133-bcfb-3e3dedb934b3" />

<img width="1669" height="455" alt="image" src="https://github.com/user-attachments/assets/f7ef514f-78f3-4c49-be38-38103069a962" />

Test matrix:
- To fields validate correctly
- CC / BCC work during message delivery
- CC / BCC work during test message