### PR TITLE
Prevent XXE in the HL7 v2.x strict parser

### DIFF
--- a/server/src/main/java/com/mirth/connect/plugins/datatypes/hl7v2/ER7Serializer.java
+++ b/server/src/main/java/com/mirth/connect/plugins/datatypes/hl7v2/ER7Serializer.java
@@ -18,9 +18,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
@@ -521,6 +524,30 @@ public class ER7Serializer implements IMessageSerializer {
             message.setParser(this);
 
             return message;
+        }
+
+        /*
+         * HAPI 2.3's XMLUtils.parse builds its DOM parser with no protection against external XML
+         * entities, so a strict-parsed inbound message carrying a DOCTYPE can trigger XXE (SSRF and
+         * local file disclosure), reachable unauthenticated over an MLLP/TCP listener. This is the
+         * only method that reaches that parser, so override it to reject any DOCTYPE up front, using
+         * the same disallow-doctype-decl hardening already applied to the fromXML path above.
+         * Legitimate HL7 v2.x XML never contains a DOCTYPE.
+         *
+         * This stays stronger than HAPI's own >= 2.4 fix, which permits a DOCTYPE and only disables
+         * entity resolution. Remove only once HAPI is upgraded to >= 2.4 AND that weaker posture is
+         * deliberately accepted.
+         */
+        @Override
+        protected synchronized Document parseStringIntoDocument(String xml) throws HL7Exception {
+            try {
+                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setNamespaceAware(true);
+                return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+            } catch (Exception e) {
+                throw new HL7Exception("Exception parsing XML", e);
+            }
         }
     }
 

--- a/server/src/test/java/com/mirth/connect/plugins/datatypes/hl7v2/ER7SerializerTest.java
+++ b/server/src/test/java/com/mirth/connect/plugins/datatypes/hl7v2/ER7SerializerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.SAXParseException;
@@ -15,42 +16,89 @@ import com.mirth.connect.model.datatype.SerializerProperties;
 
 public class ER7SerializerTest {
 	private static ER7Serializer serializer;
-	
+	// Strict parser with strict validation: XML input is parsed by HAPI (the XXE sink).
+	private static ER7Serializer strictValidatingSerializer;
+
 	@BeforeClass
 	public static void setupClass() throws Exception {
 		SerializerProperties serializerProperties = new SerializerProperties(new HL7v2SerializationProperties(), new HL7v2DeserializationProperties(), null);
 		serializer = new ER7Serializer(serializerProperties);
+
+		HL7v2SerializationProperties strictValidatingProperties = new HL7v2SerializationProperties();
+		strictValidatingProperties.setUseStrictParser(true);
+		strictValidatingProperties.setUseStrictValidation(true);
+		strictValidatingSerializer = new ER7Serializer(new SerializerProperties(strictValidatingProperties, new HL7v2DeserializationProperties(), null));
 	}
-	
+
 	@Test
 	public void testFromXMLWithExternalDTD() throws Exception {
 		String xml = FileUtils.readFileToString(new File("tests/test-xxe-hl7-example.xml"), "UTF-8");
-		
+
 		boolean exceptionThrown = false;
 		try {
 			serializer.fromXML(xml);
 		} catch (MessageSerializerException e) {
 			exceptionThrown = true;
-			
+
 			// See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j
 			assertTrue(e.getCause() instanceof SAXParseException);
 		}
-		
+
 		assertTrue(exceptionThrown);
 	}
 
 	@Test
 	public void testValidFromXMLWithExternalDTD() throws Exception {
 		String xml = FileUtils.readFileToString(new File("tests/test-xxe-hl7-example-valid.xml"), "UTF-8");
-		
+
 		boolean exceptionThrown = false;
 		try {
 			serializer.fromXML(xml);
 		} catch (MessageSerializerException e) {
 			exceptionThrown = true;
-			
+
 		}
-		
+
+		assertFalse(exceptionThrown);
+	}
+
+	@Test
+	public void testToXmlStrictValidatingRejectsExternalDTD() throws Exception {
+		// A DOCTYPE-bearing message on the strict-parser toXML path is the unauthenticated MLLP XXE
+		// vector (HAPI 2.3 resolved external entities). It must be rejected rather than have its
+		// external entity resolved. Note: this asserts the intended behavior; the discriminating
+		// before/after proof that the override (not incidental parser behavior) closes the XXE is the
+		// live MLLP reproduction documented in the PR.
+		String xml = FileUtils.readFileToString(new File("tests/test-xxe-hl7-strict-mllp.xml"), "UTF-8");
+
+		boolean exceptionThrown = false;
+		try {
+			strictValidatingSerializer.toXML(xml);
+		} catch (MessageSerializerException e) {
+			exceptionThrown = true;
+
+			// The rejection must be the DOCTYPE being disallowed, not some incidental parse failure.
+			Throwable rootCause = ExceptionUtils.getRootCause(e);
+			assertTrue(rootCause instanceof SAXParseException);
+			assertTrue(rootCause.getMessage().contains("DOCTYPE"));
+		}
+
+		assertTrue(exceptionThrown);
+	}
+
+	@Test
+	public void testToXmlStrictValidatingAllowsValidXml() throws Exception {
+		// The same message without a DOCTYPE is legitimate HL7 v2.x XML and must still round-trip, so
+		// the hardening does not break the strict parser's XML support.
+		String xml = FileUtils.readFileToString(new File("tests/test-xxe-hl7-strict-mllp-valid.xml"), "UTF-8");
+
+		boolean exceptionThrown = false;
+		try {
+			strictValidatingSerializer.toXML(xml);
+		} catch (MessageSerializerException e) {
+			exceptionThrown = true;
+		}
+
 		assertFalse(exceptionThrown);
 	}
 }

--- a/server/tests/test-xxe-hl7-strict-mllp-valid.xml
+++ b/server/tests/test-xxe-hl7-strict-mllp-valid.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<ACK xmlns="urn:hl7-org:v2xml"><MSH><MSH.1>|</MSH.1><MSH.2>^~\&amp;</MSH.2><MSH.3><HD.1>APP</HD.1></MSH.3><MSH.9><MSG.1>ACK</MSG.1></MSH.9><MSH.10>1</MSH.10><MSH.12><VID.1>2.4</VID.1></MSH.12></MSH><MSA><MSA.1>AA</MSA.1><MSA.2>1</MSA.2></MSA></ACK>

--- a/server/tests/test-xxe-hl7-strict-mllp.xml
+++ b/server/tests/test-xxe-hl7-strict-mllp.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<!DOCTYPE ACK [ <!ENTITY xxe SYSTEM "tests/test-dtd"> ]>
+<ACK xmlns="urn:hl7-org:v2xml"><MSH><MSH.1>|</MSH.1><MSH.2>^~\&amp;</MSH.2><MSH.3><HD.1>&xxe;</HD.1></MSH.3><MSH.9><MSG.1>ACK</MSG.1></MSH.9><MSH.10>1</MSH.10><MSH.12><VID.1>2.4</VID.1></MSH.12></MSH><MSA><MSA.1>AA</MSA.1><MSA.2>1</MSA.2></MSA></ACK>


### PR DESCRIPTION
## Summary

The HL7 v2.x strict parser hands XML-encoded inbound messages to the bundled HAPI 2.3, whose `XMLUtils.parse` resolves external XML entities with no hardening. On a channel with **Use Strict Parser** + **Validate in Strict Parser**, an unauthenticated message to the MLLP/TCP listener could trigger SSRF (internal services, cloud metadata) and local file disclosure. Reported as oie-1; also independently reported by Samuel Paschuan.

## Fix

`ER7Serializer.CustomDefaultXMLParser.parseStringIntoDocument` — the sole path from OIE to the vulnerable parser — is overridden to reject `DOCTYPE` declarations, matching the `disallow-doctype-decl` hardening already used on the sibling `fromXML` path (and ~20 other XML parse sites in the tree).

This is a minimal, non-breaking change. The format the strict parser handles — the official HL7 v2.xml encoding (`urn:hl7-org:v2xml`) — is defined by XML Schema, not DTDs, so a standards-conformant message does not use a DOCTYPE and is unaffected. (This is distinct from Mirth's own non-strict `<HL7Message>` format, which is a separate code path the override does not touch, and which is already DOCTYPE-hardened on the `fromXML` side.) Any inbound message that *does* carry a DOCTYPE is now rejected rather than parsed — that is the intended hardening, since at the parser level a DOCTYPE-bearing message is indistinguishable from the attack. Existing channels need no changes: no new options, no migration, no configuration.

## How this was verified

- **Confirmed the vulnerability at the bytecode level.** Disassembled `hapi-base-2.3.jar`: `XMLUtils` sets no doctype or external-entity restrictions.
- **Confirmed the fix is comprehensive at a single chokepoint.** `parseStringIntoDocument` is the only caller of `XMLUtils.parse` across all HAPI parser classes, and both of OIE's parser instances (serialization + deserialization) are the overridden `CustomDefaultXMLParser` — it is the only HAPI XML parser instantiated in the server/donkey tree.
- **Live MLLP before/after (the authoritative proof).** Imported the `xxe-poc` channel (MLLP :6661, strict + strict validation), sent the report's payload against an out-of-band HTTP catcher:
  - Unpatched build: the catcher logged the callback — SSRF fired, unauthenticated.
  - Patched build: `DOCTYPE is disallowed` — the message is rejected and the server never calls out.

## Tests

Unit tests fire the report's payload on the strict `toXML` path and assert the parse is rejected with a `DOCTYPE`-disallowed root cause, alongside a benign v2.xml message that still round-trips (the hardening does not break valid XML).

Honest caveat: the DOCTYPE-rejection unit test asserts the intended behavior but does not by itself discriminate patched from unpatched, because the test-JVM's default XML parser rejects a DOCTYPE regardless — the engine runtime is where HAPI resolves a different, vulnerable parser. The discriminating before/after evidence is the live MLLP reproduction above.

## Follow-ups (separate)

- **HAPI upgrade** — the `hapi-structures` 2.3 → 2.6.0 bump is tracked by Renovate in the Dependency Dashboard (#386); the vendored `hapi-base` jar needs replacing alongside it. This override should stay even after the upgrade: HAPI's 2.4+ fix leaves `disallow-doctype-decl=false` (permits a DOCTYPE, only disables entity resolution), so this refusal is the stronger posture.
- **Optional surface reduction** — an "Allow XML" data type toggle to let a strict HL7 channel refuse XML input entirely (mgaffigan's #406) is a separate enhancement, not a security control, and is deliberately out of scope here.
- A distinct XXE in the generic XML data type's batch adaptor (`XMLBatchAdaptor` parses inbound content with an unhardened `XPathFactory`) was found during this work and will be filed and fixed separately.

## Credits

Thanks to Samuel Paschuan for reporting the issue, and to Michael Gaffigan (@mgaffigan) and Tony Germano for the design discussion.
