### PR TITLE
Stop failed logins from revealing which usernames exist

### DIFF
--- a/server/conf/mirth.properties
+++ b/server/conf/mirth.properties
@@ -21,6 +21,11 @@ password.graceperiod = 0
 password.reuseperiod = 0
 password.reuselimit = 0
 
+# When false (the default), failed logins return a generic "Incorrect username or password."
+# message. Set to true to restore detailed messages that reveal account lockout state and
+# remaining attempts. Warning: enabling this lets an attacker enumerate valid usernames.
+password.allowdetailedautherrors = false
+
 # Only used for migration purposes, do not modify
 version = 4.6.0
 

--- a/server/src/main/java/com/mirth/connect/model/PasswordRequirements.java
+++ b/server/src/main/java/com/mirth/connect/model/PasswordRequirements.java
@@ -29,6 +29,7 @@ public class PasswordRequirements implements Serializable {
     private int gracePeriod;
     private int reusePeriod;
     private int reuseLimit;
+    private boolean allowDetailedAuthErrors;
 
     public PasswordRequirements() {
         this.minLength = 0;
@@ -42,6 +43,7 @@ public class PasswordRequirements implements Serializable {
         this.gracePeriod = 0;
         this.reusePeriod = 0;
         this.reuseLimit = 0;
+        this.allowDetailedAuthErrors = false;
     }
 
     public PasswordRequirements(int minLength, int minUpper, int minLower, int minNumeric, int minSpecial, int retryLimit, int lockoutPeriod, int expiration, int gracePeriod, int reusePeriod, int reuseLimit) {
@@ -56,6 +58,7 @@ public class PasswordRequirements implements Serializable {
         this.gracePeriod = gracePeriod;
         this.reusePeriod = reusePeriod;
         this.reuseLimit = reuseLimit;
+        this.allowDetailedAuthErrors = false;
     }
 
     public int getMinLength() {
@@ -144,5 +147,13 @@ public class PasswordRequirements implements Serializable {
 
     public void setReuseLimit(int reuseLimit) {
         this.reuseLimit = reuseLimit;
+    }
+
+    public boolean getAllowDetailedAuthErrors() {
+        return allowDetailedAuthErrors;
+    }
+
+    public void setAllowDetailedAuthErrors(boolean allowDetailedAuthErrors) {
+        this.allowDetailedAuthErrors = allowDetailedAuthErrors;
     }
 }

--- a/server/src/main/java/com/mirth/connect/server/controllers/DefaultUserController.java
+++ b/server/src/main/java/com/mirth/connect/server/controllers/DefaultUserController.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -43,6 +44,12 @@ import com.mirth.connect.server.util.StatementLock;
 public class DefaultUserController extends UserController {
     public static final String VACUUM_LOCK_PERSON_STATEMENT_ID = "User.vacuumPersonTable";
     public static final String VACUUM_LOCK_PREFERENCES_STATEMENT_ID = "User.vacuumPersonPreferencesTable";
+    private static final String INCORRECT_CREDENTIALS_MESSAGE = "Incorrect username or password.";
+    private static final String TIMING_EQUALIZATION_PASSWORD = "password used only to equalize authentication timing";
+
+    private final Object timingEqualizationLock = new Object();
+    private volatile String timingEqualizationHash;
+    private final AtomicBoolean timingEqualizationFailureLogged = new AtomicBoolean();
 
     private Logger logger = LogManager.getLogger(this.getClass());
     private ExtensionController extensionController = null;
@@ -301,15 +308,22 @@ public class DefaultUserController extends UserController {
             boolean authorized = false;
             Credentials credentials = null;
             LoginRequirementsChecker loginRequirementsChecker = null;
+            PasswordRequirements passwordRequirements = ControllerFactory.getFactory().createConfigurationController().getPasswordRequirements();
+            Digester digester = ControllerFactory.getFactory().createConfigurationController().getDigester();
 
             // Retrieve the matching User
             User validUser = getUser(null, username);
 
             if (validUser != null) {
-                Digester digester = ControllerFactory.getFactory().createConfigurationController().getDigester();
                 loginRequirementsChecker = new LoginRequirementsChecker(validUser);
                 if (loginRequirementsChecker.isUserLockedOut()) {
-                    return new LoginStatus(LoginStatus.Status.FAIL_LOCKED_OUT, "User account \"" + username + "\" has been locked. You may attempt to login again in " + loginRequirementsChecker.getPrintableStrikeTimeRemaining() + ".");
+                    equalizeAuthenticationTime(digester, plainPassword);
+
+                    if (passwordRequirements.getAllowDetailedAuthErrors()) {
+                        return new LoginStatus(LoginStatus.Status.FAIL_LOCKED_OUT, "User account \"" + username + "\" has been locked. You may attempt to login again in " + loginRequirementsChecker.getPrintableStrikeTimeRemaining() + ".");
+                    } else {
+                        return new LoginStatus(LoginStatus.Status.FAIL, INCORRECT_CREDENTIALS_MESSAGE);
+                    }
                 }
 
                 loginRequirementsChecker.resetExpiredStrikes();
@@ -322,14 +336,21 @@ public class DefaultUserController extends UserController {
                         if (Pre22PasswordChecker.checkPassword(plainPassword, credentials.getPassword())) {
                             checkOrUpdateUserPassword(validUser.getId(), plainPassword);
                             authorized = true;
+                        } else {
+                            // A pre-2.2 hash is checked with a cheap digest, so equalize the miss
+                            equalizeAuthenticationTime(digester, plainPassword);
                         }
                     } else {
                         authorized = digester.matches(plainPassword, credentials.getPassword());
                     }
+                } else {
+                    // The account exists but has never had a password set
+                    equalizeAuthenticationTime(digester, plainPassword);
                 }
+            } else {
+                equalizeAuthenticationTime(digester, plainPassword);
             }
 
-            PasswordRequirements passwordRequirements = ControllerFactory.getFactory().createConfigurationController().getPasswordRequirements();
             LoginStatus loginStatus = null;
 
             if (authorized) {
@@ -392,12 +413,12 @@ public class DefaultUserController extends UserController {
                 }
             } else {
                 LoginStatus.Status status = LoginStatus.Status.FAIL;
-                String failMessage = "Incorrect username or password.";
+                String failMessage = INCORRECT_CREDENTIALS_MESSAGE;
 
                 if (loginRequirementsChecker != null) {
                     loginRequirementsChecker.incrementStrikes();
 
-                    if (loginRequirementsChecker.isLockoutEnabled()) {
+                    if (loginRequirementsChecker.isLockoutEnabled() && passwordRequirements.getAllowDetailedAuthErrors()) {
                         if (loginRequirementsChecker.isUserLockedOut()) {
                             status = LoginStatus.Status.FAIL_LOCKED_OUT;
                             failMessage += " User account \"" + username + "\" has been locked. You may attempt to login again in " + loginRequirementsChecker.getPrintableStrikeTimeRemaining() + ".";
@@ -626,6 +647,43 @@ public class DefaultUserController extends UserController {
             logger.error("Could not delete preference: user id=" + id + ", name=" + name, e);
         } finally {
             StatementLock.getInstance(VACUUM_LOCK_PREFERENCES_STATEMENT_ID).readUnlock();
+        }
+    }
+
+    /**
+     * Performs a throwaway password digest so that a failed login costs roughly the same whether or
+     * not the username exists, and whether or not the account is locked out. The real digest is only
+     * reached for a valid, unlocked user, so without this the response time alone identifies which
+     * usernames are real regardless of what the response message says.
+     *
+     * Called on every path that skips the real digest: an unknown username, a locked account, an
+     * account with no stored credentials, and a failed pre-2.2 hash check.
+     *
+     * The throwaway hash is generated once from the live digester, so it follows the configured
+     * algorithm and iteration count rather than a value baked in here.
+     *
+     * ponytail: equalizes the digest only, not the extra credentials query a valid user costs.
+     * That gap measured under 1ms against a 237ms floor. Revisit if the digest cost ever drops
+     * far enough for a sub-millisecond difference to be readable.
+     */
+    private void equalizeAuthenticationTime(Digester digester, String plainPassword) {
+        try {
+            String hash = timingEqualizationHash;
+
+            if (hash == null) {
+                synchronized (timingEqualizationLock) {
+                    if (timingEqualizationHash == null) {
+                        timingEqualizationHash = digester.digest(TIMING_EQUALIZATION_PASSWORD);
+                    }
+                    hash = timingEqualizationHash;
+                }
+            }
+
+            digester.matches(plainPassword, hash);
+        } catch (Exception e) {
+            if (timingEqualizationFailureLogged.compareAndSet(false, true)) {
+                logger.warn("Unable to equalize authentication timing. Until this is resolved, the time taken to reject a login reveals whether the username exists. This is logged once per server run.", e);
+            }
         }
     }
 

--- a/server/src/main/java/com/mirth/connect/server/util/PasswordRequirementsChecker.java
+++ b/server/src/main/java/com/mirth/connect/server/util/PasswordRequirementsChecker.java
@@ -57,6 +57,7 @@ public class PasswordRequirementsChecker implements Serializable {
     private static final String PASSWORD_LOCKOUT_PERIOD = "password.lockoutperiod";
     private static final String PASSWORD_REUSE_PERIOD = "password.reuseperiod";
     private static final String PASSWORD_REUSE_LIMIT = "password.reuselimit";
+    private static final String PASSWORD_ALLOW_DETAILED_AUTH_ERRORS = "password.allowdetailedautherrors";
 
     private static PasswordRequirementsChecker instance = null;
 
@@ -88,6 +89,7 @@ public class PasswordRequirementsChecker implements Serializable {
         passwordRequirements.setLockoutPeriod(securityProperties.getInt(PASSWORD_LOCKOUT_PERIOD, 0));
         passwordRequirements.setReusePeriod(securityProperties.getInt(PASSWORD_REUSE_PERIOD, 0));
         passwordRequirements.setReuseLimit(securityProperties.getInt(PASSWORD_REUSE_LIMIT, 0));
+        passwordRequirements.setAllowDetailedAuthErrors(securityProperties.getBoolean(PASSWORD_ALLOW_DETAILED_AUTH_ERRORS, false));
 
         return passwordRequirements;
     }

--- a/server/src/test/java/com/mirth/connect/server/controllers/DefaultUserControllerAuthorizeUserTest.java
+++ b/server/src/test/java/com/mirth/connect/server/controllers/DefaultUserControllerAuthorizeUserTest.java
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: Open Integration Engine
+
+package com.mirth.connect.server.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Calendar;
+
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSessionManager;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.mirth.commons.encryption.Digester;
+import com.mirth.connect.model.LoginStatus;
+import com.mirth.connect.model.PasswordRequirements;
+import com.mirth.connect.model.User;
+import com.mirth.connect.server.util.SqlConfig;
+
+/**
+ * Covers what a failed login tells the caller. A locked account used to name itself and report its
+ * remaining lock time, which let an unauthenticated caller tell a real username from a made-up one.
+ *
+ * These assert on the returned LoginStatus only. Whether the two cases take the same amount of time
+ * is a separate property that is measured against a running server, not asserted here.
+ */
+public class DefaultUserControllerAuthorizeUserTest {
+
+    private static final String LOCKED_USERNAME = "lockeduser";
+    private static final String UNKNOWN_USERNAME = "nosuchuser";
+    private static final String WRONG_PASSWORD = "wrongpassword";
+    private static final String GENERIC_MESSAGE = "Incorrect username or password.";
+
+    private static ControllerFactory controllerFactory;
+    private static ConfigurationController configurationController;
+    private static ExtensionController extensionController;
+    private static UserController userController;
+
+    private PasswordRequirements passwordRequirements;
+    private DefaultUserController controller;
+
+    @BeforeClass
+    public static void setupBeforeClass() {
+        controllerFactory = mock(ControllerFactory.class);
+        configurationController = mock(ConfigurationController.class);
+        extensionController = mock(ExtensionController.class);
+        userController = mock(UserController.class);
+
+        when(controllerFactory.createConfigurationController()).thenReturn(configurationController);
+        when(controllerFactory.createExtensionController()).thenReturn(extensionController);
+        when(controllerFactory.createUserController()).thenReturn(userController);
+
+        /*
+         * authorizeUser takes a StatementLock, and StatementLock asks DatabaseUtil whether the
+         * vacuum statement is mapped, which builds a real SqlConfig and its connection pool. Report
+         * the statement as absent so the lock is a no-op and nothing tries to reach a database.
+         */
+        SqlConfig sqlConfig = mock(SqlConfig.class);
+        SqlSessionManager sqlSessionManager = mock(SqlSessionManager.class);
+        Configuration mybatisConfiguration = mock(Configuration.class);
+        when(sqlConfig.getSqlSessionManager()).thenReturn(sqlSessionManager);
+        when(sqlSessionManager.getConfiguration()).thenReturn(mybatisConfiguration);
+        when(mybatisConfiguration.getMappedStatement(ArgumentMatchers.anyString()))
+                .thenThrow(new IllegalArgumentException("statement not mapped in this test"));
+
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                requestStaticInjection(ControllerFactory.class);
+                requestStaticInjection(SqlConfig.class);
+                bind(ControllerFactory.class).toInstance(controllerFactory);
+                bind(SqlConfig.class).toInstance(sqlConfig);
+            }
+        });
+        injector.getInstance(ControllerFactory.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        reset(configurationController, extensionController, userController);
+
+        // No authorization or MFA plugin, so the controller performs authentication itself
+        when(extensionController.getAuthorizationPlugin()).thenReturn(null);
+        when(extensionController.getMultiFactorAuthenticationPlugin()).thenReturn(null);
+
+        passwordRequirements = new PasswordRequirements();
+        passwordRequirements.setRetryLimit(3);
+        passwordRequirements.setLockoutPeriod(1);
+        when(configurationController.getPasswordRequirements()).thenReturn(passwordRequirements);
+        when(configurationController.getDigester()).thenReturn(mock(Digester.class));
+
+        controller = spy(new DefaultUserController());
+        doReturn(lockedUser()).when(controller).getUser(null, LOCKED_USERNAME);
+        doReturn(null).when(controller).getUser(null, UNKNOWN_USERNAME);
+    }
+
+    @Test
+    public void lockedAccountIsGenericByDefault() throws Exception {
+        LoginStatus status = controller.authorizeUser(LOCKED_USERNAME, WRONG_PASSWORD, null);
+
+        assertEquals(LoginStatus.Status.FAIL, status.getStatus());
+        assertEquals(GENERIC_MESSAGE, status.getMessage());
+    }
+
+    @Test
+    public void lockedAccountReportsDetailWhenAllowed() throws Exception {
+        passwordRequirements.setAllowDetailedAuthErrors(true);
+
+        LoginStatus status = controller.authorizeUser(LOCKED_USERNAME, WRONG_PASSWORD, null);
+
+        assertEquals(LoginStatus.Status.FAIL_LOCKED_OUT, status.getStatus());
+        assertTrue("expected the message to name the account, but was: " + status.getMessage(),
+                status.getMessage().contains(LOCKED_USERNAME));
+    }
+
+    /**
+     * The #240 regression test. Without the fix the locked account answers FAIL_LOCKED_OUT and names
+     * itself while the unknown username answers FAIL, so the two responses identify a real account.
+     */
+    @Test
+    public void lockedAccountIsIndistinguishableFromUnknownUsername() throws Exception {
+        LoginStatus locked = controller.authorizeUser(LOCKED_USERNAME, WRONG_PASSWORD, null);
+        LoginStatus unknown = controller.authorizeUser(UNKNOWN_USERNAME, WRONG_PASSWORD, null);
+
+        assertEquals(unknown.getStatus(), locked.getStatus());
+        assertEquals(unknown.getMessage(), locked.getMessage());
+    }
+
+    /**
+     * Strikes past the retry limit with the last one just now, so the lockout period has not
+     * elapsed. LoginRequirementsChecker reads both values straight off the User.
+     */
+    private User lockedUser() {
+        User user = new User();
+        user.setId(1);
+        user.setUsername(LOCKED_USERNAME);
+        user.setStrikeCount(passwordRequirements.getRetryLimit() + 1);
+        user.setLastStrikeTime(Calendar.getInstance());
+        return user;
+    }
+}

--- a/server/src/test/java/com/mirth/connect/server/util/PasswordRequirementsTest.java
+++ b/server/src/test/java/com/mirth/connect/server/util/PasswordRequirementsTest.java
@@ -9,12 +9,14 @@
 
 package com.mirth.connect.server.util;
 
+import org.apache.commons.configuration2.PropertiesConfiguration;
+
 import junit.framework.TestCase;
 
 import com.mirth.connect.client.core.ControllerException;
 import com.mirth.connect.model.PasswordRequirements;
 
-public class PasswordRequirementsTests extends TestCase {
+public class PasswordRequirementsTest extends TestCase {
 
     protected void setUp() throws Exception {
         super.setUp();
@@ -78,5 +80,17 @@ public class PasswordRequirementsTests extends TestCase {
         PasswordRequirements req = new PasswordRequirements(15, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0);
         assertNotNull(PasswordRequirementsChecker.getInstance().doesPasswordMeetRequirements(null, "test", req));
         assertNull(PasswordRequirementsChecker.getInstance().doesPasswordMeetRequirements(null, "Th1$isAtestTEST*#", req));
+    }
+
+    public void testAllowDetailedAuthErrorsDefaultsToFalse() {
+        PasswordRequirements req = PasswordRequirementsChecker.getInstance().loadPasswordRequirements(new PropertiesConfiguration());
+        assertFalse(req.getAllowDetailedAuthErrors());
+    }
+
+    public void testAllowDetailedAuthErrorsHonorsProperty() {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty("password.allowdetailedautherrors", true);
+        PasswordRequirements req = PasswordRequirementsChecker.getInstance().loadPasswordRequirements(properties);
+        assertTrue(req.getAllowDetailedAuthErrors());
     }
 }


### PR DESCRIPTION
Fixes #240.

A failed login gave away whether the username was real, in two separate ways. This fixes both.

### The messages

The lockout paths in `DefaultUserController.authorizeUser` named the account and reported how long the lock had left to run, so an unauthenticated caller could tell a valid username from an invalid one. Both sites now return a generic `Incorrect username or password.` unless `password.allowdetailedautherrors` is set, which defaults to false.

### The timing

Fixing the messages alone left a second and much larger signal in place. Closing #240 on the message fix by itself would have overstated what changed.

The password digest is only reached for a valid, unlocked user. An unknown username never enters the `validUser != null` block, and a locked account returns before it, so both skipped 600,000 PBKDF2 iterations. Measured with generic messages already enabled, 250 samples per cohort:

| cohort | median | p10 | p90 |
|---|---|---|---|
| valid + unlocked | 230.90 ms | 227.52 | 234.27 |
| valid + locked | 0.49 ms | 0.42 | 0.72 |
| invalid username | 0.76 ms | 0.66 | 0.93 |

The distributions do not overlap. The fastest unlocked sample was still 240x slower than the slowest locked one, so one timed request classified any username whatever the response body said. An attacker could enumerate accounts without reading a message at all.

A same-account control confirms the cause. An account that crossed the strike limit partway through a run stepped from 232.03 ms to 0.33 ms at the boundary, with no samples in between. The account did not change, only its lockout state did.

Every path that skips the real digest now runs a throwaway one and discards the result: an unknown username, a locked account, an account that exists but has never had a password set, and a failed pre-2.2 hash check. The last two are reachable in normal use, since an admin can create an account before provisioning it and legacy hashes survive upgrades. The throwaway goes through `matches()` so the fallback digester runs the way it does on the real path, and the hash is generated once from the live digester so it follows the configured algorithm and iteration count. Measured again on the same rig by the same method:

| cohort | before | after |
|---|---|---|
| valid + unlocked | 230.90 ms | 237.74 ms |
| valid + locked | 0.49 ms | 236.84 ms |
| invalid username | 0.76 ms | 237.05 ms |
| worst ratio | 470x | 1.00x |

The no-password case was checked separately against a real account and came back at 234.16 ms against 233.89 for a valid user and 233.45 for an unknown one.

This is not constant time and I am not claiming it is. A valid user still costs one extra credentials query that a miss does not, which measured under a millisecond against a 237 ms floor. There is a `ponytail:` marker on the helper naming that ceiling and the condition for revisiting it.

There is a tradeoff here worth arguing with. Locked accounts are no longer cheap to reject, so lockout no longer caps the cost of repeatedly probing an account already known to exist. My reasoning is that an attacker gains nothing by locking an account once every username costs the same, so that cheapness was mostly helping the attacker. Tell me if you see it differently.

### What this does not cover

An `AuthorizationPlugin` returning a non-null `LoginStatus` returns before any of this code, so OIDC, LDAP and similar plugins are unaffected in both directions: nothing here breaks them, and nothing here protects them. Their messages and timing are their own. A plugin that replaces `UserController` outright through `ExtensionLoader` would miss this entirely, and grepping this repo will not reveal one.

### Tests

`DefaultUserControllerAuthorizeUserTest` covers the message behaviour: a locked account is generic by default, reports detail when the property is set, and is indistinguishable from an unknown username. The first and third fail against current main and pass with this change, so they are regression tests rather than a description of the new code. The second passes either way by design, since the detailed message used to be unconditional; it guards the escape hatch.

It binds mock `ControllerFactory` and `SqlConfig` through Guice static injection, the way `DefaultHttpConfigurationTest` already does, so no database is involved. Lockout state is set directly on the `User`, because `LoginRequirementsChecker` reads the strike count and last strike time straight off it.

No test asserts the timing. Mocking the digester removes the cost being measured, and a real one makes every call take 230 ms and turns the suite into a flaky performance test. The numbers above come from a running server.

**Not added: a smoke test in `ci/`.** The new harness boots a real engine across seven configurations and has a Java seam with a live `Client`, so the message behaviour could be asserted there against all five databases. That is worth doing and I have not done it; it belongs in its own change rather than growing this one further. The timing assertion would still be a poor fit for shared runners.

Clean build, 686 tests, 0 failures.

### Credit

This is @mgaffigan's fix from #241, reworked for the current source layout. That branch predates the June move to `src/main/java` and no longer applies. His PR should close in favour of this one. The timing half is new.

### Naming

Uses `allowDetailedAuthErrors`, which @tonygermano suggested on #241 and @mgaffigan declined, wanting a name that sounds alarming rather than helpful.

I have gone with Tony's, on a ground that was not available in January. The measurements above show that suppressing the messages does not by itself prevent username enumeration. A flag called `allowUsernameEnumeration` would promise a guarantee the flag cannot keep, and an admin who set it false would reasonably believe the hole was closed. `allowDetailedAuthErrors` describes exactly what it controls, which after this PR is only the messages, because enumeration is now handled separately and unconditionally.

### Constructor

The field is set explicitly in both constructors, per @tonygermano's note that every other property is. I have not added a twelfth constructor argument. Production builds this through the no-arg constructor and setters, so widening the signature would only churn `SwaggerExamplesServlet` and the existing tests to thread a parameter nothing reads.

### Test rename

`PasswordRequirementsTests` becomes `PasswordRequirementsTest`. The build includes `**/*Test.class` only, so the plural-named class has never run in any build. Six dormant cases now execute and pass, alongside two new ones for the property. The dead `*Tests` problem is wider than this file and needs its own issue.

### Behavior change

With the property unset, messages go from detailed to generic. That is deliberate and secure by default, but it is still a change, and anything scraping the message string will notice. Raised on #241 by me and @ChristopherSchultz.

### How to verify by hand

Defaults are `retrylimit = 100` and `lockoutperiod = 1`. That period is in hours rather than minutes, per `Duration.standardHours` at `LoginRequirementsChecker:99`.

1. `POST /api/users/_login` with a valid username and wrong password, 101 times
2. Send the same request against a nonexistent username. The responses are byte-identical
3. Retry the valid user with the correct password. It still fails generically, which confirms the lock is real and the gated branch ran
4. Time all three cases. They land within a millisecond or two of each other instead of 300x apart
5. Set `password.allowdetailedautherrors = true`, restart and repeat. The account name and remaining time come back, and the timings stay equal
